### PR TITLE
Add minimum spanning tree algorithm

### DIFF
--- a/src/graaflib/algorithm/minimum_spanning_tree.h
+++ b/src/graaflib/algorithm/minimum_spanning_tree.h
@@ -1,0 +1,78 @@
+#pragma once
+
+#include <vector>
+#include <utility>
+#include <algorithm>
+
+#include <graaflib/graph.h>
+#include <graaflib/types.h>
+
+namespace graaf::algorithm {
+
+// Helper struct for representing disjoint sets
+struct DisjointSet {
+  std::vector<vertex_id_t> parent;
+  std::vector<size_t> rank;
+
+  DisjointSet(size_t num_vertices) {
+    parent.resize(num_vertices);
+    rank.resize(num_vertices, 0);
+    for (vertex_id_t i = 0; i < num_vertices; ++i)
+      parent[i] = i;
+  }
+
+  vertex_id_t find(vertex_id_t vertex) {
+    if (vertex != parent[vertex])
+      parent[vertex] = find(parent[vertex]);
+    return parent[vertex];
+  }
+
+  void union_sets(vertex_id_t vertex1, vertex_id_t vertex2) {
+    vertex_id_t root1 = find(vertex1);
+    vertex_id_t root2 = find(vertex2);
+    if (root1 != root2) {
+      if (rank[root1] < rank[root2])
+        std::swap(root1, root2);
+      parent[root2] = root1;
+      if (rank[root1] == rank[root2])
+        ++rank[root1];
+    }
+  }
+};
+
+template <typename V, typename E, graph_spec S>
+std::vector<std::pair<vertex_id_t, vertex_id_t>> minimum_spanning_tree(const graph<V, E, S>& graph) {
+  using Edge = std::pair<edge_weight_t, std::pair<vertex_id_t, vertex_id_t>>;
+  std::vector<Edge> edges;
+
+  // Populate the edges vector with all edges in the graph
+  for (vertex_id_t source = 0; source < graph.num_vertices(); ++source) {
+    for (auto edge : graph.get_outgoing_edges(source)) {
+      vertex_id_t target = edge.target;
+      edge_weight_t weight = edge.weight;
+      edges.push_back({weight, {source, target}});
+    }
+  }
+
+  // Sort the edges in ascending order based on their weights
+  std::sort(edges.begin(), edges.end());
+
+  // Initialize the minimum spanning tree and the disjoint set
+  std::vector<std::pair<vertex_id_t, vertex_id_t>> minimum_spanning_tree;
+  DisjointSet disjoint_set(graph.num_vertices());
+
+  // Perform Kruskal's algorithm
+  for (const auto& edge : edges) {
+    vertex_id_t source = edge.second.first;
+    vertex_id_t target = edge.second.second;
+
+    if (disjoint_set.find(source) != disjoint_set.find(target)) {
+      disjoint_set.union_sets(source, target);
+      minimum_spanning_tree.push_back({source, target});
+    }
+  }
+
+  return minimum_spanning_tree;
+}
+
+}  // namespace graaf::algorithm

--- a/src/graaflib/algorithm/minimum_spanning_tree.h
+++ b/src/graaflib/algorithm/minimum_spanning_tree.h
@@ -1,11 +1,11 @@
 #pragma once
 
-#include <vector>
-#include <utility>
-#include <algorithm>
-
 #include <graaflib/graph.h>
 #include <graaflib/types.h>
+
+#include <algorithm>
+#include <utility>
+#include <vector>
 
 namespace graaf::algorithm {
 
@@ -17,13 +17,11 @@ struct DisjointSet {
   DisjointSet(size_t num_vertices) {
     parent.resize(num_vertices);
     rank.resize(num_vertices, 0);
-    for (vertex_id_t i = 0; i < num_vertices; ++i)
-      parent[i] = i;
+    for (vertex_id_t i = 0; i < num_vertices; ++i) parent[i] = i;
   }
 
   vertex_id_t find(vertex_id_t vertex) {
-    if (vertex != parent[vertex])
-      parent[vertex] = find(parent[vertex]);
+    if (vertex != parent[vertex]) parent[vertex] = find(parent[vertex]);
     return parent[vertex];
   }
 
@@ -31,17 +29,16 @@ struct DisjointSet {
     vertex_id_t root1 = find(vertex1);
     vertex_id_t root2 = find(vertex2);
     if (root1 != root2) {
-      if (rank[root1] < rank[root2])
-        std::swap(root1, root2);
+      if (rank[root1] < rank[root2]) std::swap(root1, root2);
       parent[root2] = root1;
-      if (rank[root1] == rank[root2])
-        ++rank[root1];
+      if (rank[root1] == rank[root2]) ++rank[root1];
     }
   }
 };
 
 template <typename V, typename E, graph_spec S>
-std::vector<std::pair<vertex_id_t, vertex_id_t>> minimum_spanning_tree(const graph<V, E, S>& graph) {
+std::vector<std::pair<vertex_id_t, vertex_id_t>> minimum_spanning_tree(
+    const graph<V, E, S>& graph) {
   using Edge = std::pair<edge_weight_t, std::pair<vertex_id_t, vertex_id_t>>;
   std::vector<Edge> edges;
 

--- a/src/graaflib/algorithm/minimum_spanning_tree.tpp
+++ b/src/graaflib/algorithm/minimum_spanning_tree.tpp
@@ -1,0 +1,8 @@
+#include "minimum_spanning_tree.h"
+
+namespace graaf::algorithm {
+
+// No additional implementation is required for this example
+// as the entire implementation is already provided in the header file.
+
+}  // namespace graaf::algorithm

--- a/test/graaflib/algorithm/minimum_spanning_tree_test.cpp
+++ b/test/graaflib/algorithm/minimum_spanning_tree_test.cpp
@@ -1,0 +1,70 @@
+#include <cassert>
+#include <iostream>
+
+#include "minimum_spanning_tree.h"
+
+void testMinimumSpanningTree() {
+  // Test Case 1: Empty graph
+  {
+    graaf::graph<int, int> graph;
+    auto result = graaf::algorithm::minimum_spanning_tree(graph);
+    assert(result.empty());
+  }
+
+  // Test Case 2: Single vertex
+  {
+    graaf::graph<int, int> graph;
+    graph.add_vertex(0);
+    auto result = graaf::algorithm::minimum_spanning_tree(graph);
+    assert(result.empty());
+  }
+
+  // Test Case 3: Linear graph
+  {
+    graaf::graph<int, int> graph;
+    graph.add_vertex(0);
+    graph.add_vertex(1);
+    graph.add_vertex(2);
+    graph.add_vertex(3);
+    graph.add_edge(0, 1, 2);
+    graph.add_edge(1, 2, 3);
+    graph.add_edge(2, 3, 4);
+    auto result = graaf::algorithm::minimum_spanning_tree(graph);
+    std::vector<std::pair<graaf::vertex_id_t, graaf::vertex_id_t>> expected{
+        {0, 1}, {1, 2}, {2, 3}};
+    assert(result == expected);
+  }
+
+  // Test Case 4: Complete graph
+  {
+    graaf::graph<int, int> graph;
+    graph.add_vertex(0);
+    graph.add_vertex(1);
+    graph.add_vertex(2);
+    graph.add_edge(0, 1, 2);
+    graph.add_edge(0, 2, 1);
+    graph.add_edge(1, 2, 3);
+    auto result = graaf::algorithm::minimum_spanning_tree(graph);
+    std::vector<std::pair<graaf::vertex_id_t, graaf::vertex_id_t>> expected{
+        {0, 2}, {0, 1}};
+    assert(result == expected);
+  }
+
+  // Test Case 5: Graph with disconnected components
+  {
+    graaf::graph<int, int> graph;
+    graph.add_vertex(0);
+    graph.add_vertex(1);
+    graph.add_vertex(2);
+    graph.add_vertex(3);
+    graph.add_edge(0, 1, 2);
+    graph.add_edge(2, 3, 3);
+    auto result = graaf::algorithm::minimum_spanning_tree(graph);
+    std::vector<std::pair<graaf::vertex_id_t, graaf::vertex_id_t>> expected{
+        {0, 1}, {2, 3}};
+    assert(result == expected);
+  }
+
+  // If no assert fails print -
+  std::cout << "All tests passed!\n";
+}


### PR DESCRIPTION
**minimum_spanning_tree.h**

In this file, I have define a helper struct DisjointSet for managing disjoint sets. The minimum_spanning_tree function implements the Kruskal's algorithm for finding the minimum spanning tree. It utilizes the DisjointSet data structure and sorts the edges in ascending order based on their weights. The algorithm iterates over the sorted edges and adds an edge to the minimum spanning tree if it does not form a cycle.

**minimum_spanning_tree.tpp**

Since the entire implementation of the minimum_spanning_tree function is already coded in the header file, there is no additional implementation required in the "minimum_spanning_tree.tpp" file. The code in the header file is already complete and self-contained.