### PR TITLE
feat: Vertex degree [class method version]

### DIFF
--- a/src/graaflib/directed_graph.h
+++ b/src/graaflib/directed_graph.h
@@ -12,6 +12,9 @@ class directed_graph final
   [[nodiscard]] std::size_t get_vertex_outdegree(
       vertex_id_t vertex_id) const noexcept;
 
+  [[nodiscard]] std::size_t get_vertex_indegree(
+      vertex_id_t vertex_id) const noexcept;
+
  private:
   [[nodiscard]] bool do_has_edge(
       vertex_id_t vertex_id_lhs,

--- a/src/graaflib/directed_graph.h
+++ b/src/graaflib/directed_graph.h
@@ -8,6 +8,10 @@ namespace graaf {
 template <typename VERTEX_T, typename EDGE_T>
 class directed_graph final
     : public graph<VERTEX_T, EDGE_T, graph_spec::DIRECTED> {
+ public:
+  [[nodiscard]] std::size_t get_vertex_outdegree(
+      vertex_id_t vertex_id) const noexcept;
+
  private:
   [[nodiscard]] bool do_has_edge(
       vertex_id_t vertex_id_lhs,

--- a/src/graaflib/directed_graph.tpp
+++ b/src/graaflib/directed_graph.tpp
@@ -30,4 +30,10 @@ void directed_graph<VERTEX_T, EDGE_T>::do_remove_edge(
   this->edges_.erase(std::make_pair(vertex_id_lhs, vertex_id_rhs));
 }
 
+template <typename VERTEX_T, typename EDGE_T>
+std::size_t directed_graph<VERTEX_T, EDGE_T>::get_vertex_outdegree(
+    vertex_id_t vertex_id) const noexcept {
+  return (this->get_neighbors(vertex_id)).size();
+}
+
 }  // namespace graaf

--- a/src/graaflib/directed_graph.tpp
+++ b/src/graaflib/directed_graph.tpp
@@ -36,4 +36,16 @@ std::size_t directed_graph<VERTEX_T, EDGE_T>::get_vertex_outdegree(
   return (this->get_neighbors(vertex_id)).size();
 }
 
+template <typename VERTEX_T, typename EDGE_T>
+std::size_t directed_graph<VERTEX_T, EDGE_T>::get_vertex_indegree(
+    vertex_id_t vertex_id) const noexcept {
+  int indegree{0};
+  for (const auto& current_vertex : this->get_vertices()) {
+    if (this->get_neighbors(current_vertex.first).contains(vertex_id)) {
+      indegree++;
+    }
+  }
+  return indegree;
+}
+
 }  // namespace graaf

--- a/src/graaflib/undirected_graph.h
+++ b/src/graaflib/undirected_graph.h
@@ -8,6 +8,10 @@ namespace graaf {
 template <typename VERTEX_T, typename EDGE_T>
 class undirected_graph final
     : public graph<VERTEX_T, EDGE_T, graph_spec::UNDIRECTED> {
+ public:
+  [[nodiscard]] std::size_t get_vertex_degree(
+      vertex_id_t vertex_id) const noexcept;
+
  private:
   [[nodiscard]] bool do_has_edge(
       vertex_id_t vertex_id_lhs,

--- a/src/graaflib/undirected_graph.tpp
+++ b/src/graaflib/undirected_graph.tpp
@@ -45,4 +45,10 @@ void undirected_graph<VERTEX_T, EDGE_T>::do_remove_edge(
   this->edges_.erase(detail::make_sorted_pair(vertex_id_lhs, vertex_id_rhs));
 }
 
+template <typename VERTEX_T, typename EDGE_T>
+std::size_t undirected_graph<VERTEX_T, EDGE_T>::get_vertex_degree(
+    vertex_id_t vertex_id) const noexcept {
+  return (this->get_neighbors(vertex_id)).size();
+}
+
 }  // namespace graaf

--- a/test/graaflib/directed_graph_test.cpp
+++ b/test/graaflib/directed_graph_test.cpp
@@ -58,4 +58,25 @@ TEST(DirectedGraphTest, GetNeighbors) {
   ASSERT_TRUE(neighbors_vertex_3.empty());
 }
 
+TEST(DirectedGraphTest, VertexOutDegree) {
+  // GIVEN
+  directed_graph<int, int> graph{};
+
+  const auto vertex_id_1{graph.add_vertex(10)};
+  const auto vertex_id_2{graph.add_vertex(20)};
+  const auto vertex_id_3{graph.add_vertex(30)};
+  const auto vertex_id_4{graph.add_vertex(40)};
+
+  // WHEN
+  graph.add_edge(vertex_id_1, vertex_id_2, 100);
+  graph.add_edge(vertex_id_2, vertex_id_3, 200);
+  graph.add_edge(vertex_id_2, vertex_id_4, 200);
+
+  // THEN
+  ASSERT_EQ(graph.get_vertex_outdegree(vertex_id_1), 1);
+  ASSERT_EQ(graph.get_vertex_outdegree(vertex_id_2), 2);
+  ASSERT_EQ(graph.get_vertex_outdegree(vertex_id_3), 0);
+  ASSERT_EQ(graph.get_vertex_outdegree(vertex_id_4), 0);
+}
+
 }  // namespace graaf

--- a/test/graaflib/directed_graph_test.cpp
+++ b/test/graaflib/directed_graph_test.cpp
@@ -70,13 +70,35 @@ TEST(DirectedGraphTest, VertexOutDegree) {
   // WHEN
   graph.add_edge(vertex_id_1, vertex_id_2, 100);
   graph.add_edge(vertex_id_2, vertex_id_3, 200);
-  graph.add_edge(vertex_id_2, vertex_id_4, 200);
+  graph.add_edge(vertex_id_2, vertex_id_4, 300);
 
   // THEN
   ASSERT_EQ(graph.get_vertex_outdegree(vertex_id_1), 1);
   ASSERT_EQ(graph.get_vertex_outdegree(vertex_id_2), 2);
   ASSERT_EQ(graph.get_vertex_outdegree(vertex_id_3), 0);
   ASSERT_EQ(graph.get_vertex_outdegree(vertex_id_4), 0);
+}
+
+TEST(DirectedGraphTest, VertexInDegree) {
+  // GIVEN
+  directed_graph<int, int> graph{};
+
+  const auto vertex_id_1{graph.add_vertex(10)};
+  const auto vertex_id_2{graph.add_vertex(20)};
+  const auto vertex_id_3{graph.add_vertex(30)};
+  const auto vertex_id_4{graph.add_vertex(40)};
+
+  // WHEN
+  graph.add_edge(vertex_id_1, vertex_id_2, 100);
+  graph.add_edge(vertex_id_1, vertex_id_3, 200);
+  graph.add_edge(vertex_id_3, vertex_id_4, 300);
+  graph.add_edge(vertex_id_2, vertex_id_4, 400);
+
+  // THEN
+  ASSERT_EQ(graph.get_vertex_indegree(vertex_id_1), 0);
+  ASSERT_EQ(graph.get_vertex_indegree(vertex_id_2), 1);
+  ASSERT_EQ(graph.get_vertex_indegree(vertex_id_3), 1);
+  ASSERT_EQ(graph.get_vertex_indegree(vertex_id_4), 2);
 }
 
 }  // namespace graaf

--- a/test/graaflib/undirected_graph_test.cpp
+++ b/test/graaflib/undirected_graph_test.cpp
@@ -60,4 +60,22 @@ TEST(UndirectedGraphTest, GetNeighbors) {
   ASSERT_TRUE(neighbors_vertex_3.contains(vertex_id_1));
 }
 
+TEST(UndirectedGraphTest, VertexDegree) {
+  // GIVEN
+  undirected_graph<int, int> graph{};
+
+  const auto vertex_id_1{graph.add_vertex(10)};
+  const auto vertex_id_2{graph.add_vertex(20)};
+  const auto vertex_id_3{graph.add_vertex(30)};
+
+  // WHEN
+  graph.add_edge(vertex_id_1, vertex_id_2, 100);
+  graph.add_edge(vertex_id_2, vertex_id_3, 200);
+
+  // THEN
+  ASSERT_EQ(graph.get_vertex_degree(vertex_id_1), 1);
+  ASSERT_EQ(graph.get_vertex_degree(vertex_id_2), 2);
+  ASSERT_EQ(graph.get_vertex_degree(vertex_id_3), 1);
+}
+
 }  // namespace graaf


### PR DESCRIPTION
**What it does:**
- Adds the [vertex degree](https://en.wikipedia.org/wiki/Degree_(graph_theory)) for undirected graphs  and the [in-/outdegree](https://en.wikipedia.org/wiki/Indegree) for directed graphs
- Groundwork for future capabilities like detecting [Eulerians cycles and paths](https://en.wikipedia.org/wiki/Eulerian_path)
- Calculating degree for undirected graphs and outdegree for directed ones is essentially just accessing the local neighborhood. However, the indegree needs to loop over the neighborhoods of all vertices

**Food for thought for the future:**

- The performance for indegree is bad since we need to loop over all vertices. At some point, it _might_ be worth trading some memory for performance and add the incoming edges for directed graphs to the adjacency list as well (with an indicator that it's an incoming one)
- Currently, `get_vertex_degree`, `get_vertex_outdegree`, `get_vertex_indegree`, and `get_neighbors` are methods of the graph class or its derivatives. Since they primarly concern a vertex and not a graph, refactoring them into a dedicated vertex (abstract) class could be considered. The user would then inherit their vertex type from this. Tbd how the interface to the adjacency list would need to look like then
