### PR TITLE
Remove unweighted graph spec

### DIFF
--- a/examples/dot_serialization/main.cpp
+++ b/examples/dot_serialization/main.cpp
@@ -57,12 +57,13 @@ int main() {
                        vertex_id, vertex.name, color);
   }};
 
-  const auto edge_writer{[](const graaf::edge_id_t& /*edge_id*/,
-                            const my_edge& edge) -> std::string {
-    const auto style{edge.priority == edge_priority::HIGH ? "solid" : "dashed"};
-    return fmt::format("label=\"{}\", style={}, color=gray, fontcolor=gray",
-                       edge.weight, style);
-  }};
+  const auto edge_writer{
+      [](const graaf::edge_id_t& /*edge_id*/, const auto& edge) -> std::string {
+        const auto style{edge->priority == edge_priority::HIGH ? "solid"
+                                                               : "dashed"};
+        return fmt::format("label=\"{}\", style={}, color=gray, fontcolor=gray",
+                           edge->weight, style);
+      }};
 
   const std::filesystem::path dof_file_path{"./dot_example.dot"};
   graaf::io::to_dot(my_graph, dof_file_path, vertex_writer, edge_writer);

--- a/examples/shortest_path/main.cpp
+++ b/examples/shortest_path/main.cpp
@@ -66,7 +66,7 @@ int main() {
 
   const auto edge_writer{
       [&edges_on_shortest_path](const graaf::edge_id_t& edge_id,
-                                const int /*edge*/) -> std::string {
+                                const auto& /*edge*/) -> std::string {
         if (edges_on_shortest_path.contains(edge_id)) {
           return "label=\"\", color=red";
         }

--- a/include/graaflib/algorithm/graph_traversal.h
+++ b/include/graaflib/algorithm/graph_traversal.h
@@ -20,10 +20,10 @@ enum class search_strategy { DFS, BFS };
  * @param callback A callback which is called for each traversed vertex. Should
  * be invocable with a vertex_id_t.
  */
-template <search_strategy ALGORITHM, typename V, typename E, edge_type T,
-          graph_spec S, typename CALLBACK_T>
+template <search_strategy ALGORITHM, typename V, typename E, graph_spec S,
+          typename CALLBACK_T>
   requires std::invocable<const CALLBACK_T &, vertex_id_t>
-void traverse(const graph<V, E, T, S> &graph, vertex_id_t start_vertex,
+void traverse(const graph<V, E, S> &graph, vertex_id_t start_vertex,
               const CALLBACK_T &callback);
 
 }  // namespace graaf::algorithm

--- a/include/graaflib/algorithm/graph_traversal.tpp
+++ b/include/graaflib/algorithm/graph_traversal.tpp
@@ -8,9 +8,8 @@ namespace graaf::algorithm {
 
 namespace detail {
 
-template <typename V, typename E, edge_type T, graph_spec S,
-          typename CALLBACK_T>
-void do_dfs(const graph<V, E, T, S>& graph,
+template <typename V, typename E, graph_spec S, typename CALLBACK_T>
+void do_dfs(const graph<V, E, S>& graph,
             std::unordered_set<vertex_id_t>& seen_vertices, vertex_id_t current,
             const CALLBACK_T& callback) {
   callback(current);
@@ -23,9 +22,8 @@ void do_dfs(const graph<V, E, T, S>& graph,
   }
 }
 
-template <typename V, typename E, edge_type T, graph_spec S,
-          typename CALLBACK_T>
-void do_bfs(const graph<V, E, T, S>& graph,
+template <typename V, typename E, graph_spec S, typename CALLBACK_T>
+void do_bfs(const graph<V, E, S>& graph,
             std::unordered_set<vertex_id_t>& seen_vertices,
             vertex_id_t start_vertex, const CALLBACK_T& callback) {
   std::queue<vertex_id_t> to_explore{};
@@ -53,10 +51,10 @@ void do_bfs(const graph<V, E, T, S>& graph,
 
 }  // namespace detail
 
-template <search_strategy ALGORITHM, typename V, typename E, edge_type T,
-          graph_spec S, typename CALLBACK_T>
+template <search_strategy ALGORITHM, typename V, typename E, graph_spec S,
+          typename CALLBACK_T>
   requires std::invocable<const CALLBACK_T&, vertex_id_t>
-void traverse(const graph<V, E, T, S>& graph, vertex_id_t start_vertex,
+void traverse(const graph<V, E, S>& graph, vertex_id_t start_vertex,
               const CALLBACK_T& callback) {
   std::unordered_set<vertex_id_t> seen_vertices{};
 

--- a/include/graaflib/algorithm/shortest_path.h
+++ b/include/graaflib/algorithm/shortest_path.h
@@ -32,9 +32,8 @@ struct GraphPath {
  * @param start_vertex Vertex id where the shortest path should start.
  * @param end_vertex Vertex id where the shortest path should end.
  */
-template <edge_strategy EDGE_STRATEGY, typename V, typename E, edge_type T,
-          graph_spec S>
-std::optional<GraphPath<E>> get_shortest_path(const graph<V, E, T, S>& graph,
+template <edge_strategy EDGE_STRATEGY, typename V, typename E, graph_spec S>
+std::optional<GraphPath<E>> get_shortest_path(const graph<V, E, S>& graph,
                                               vertex_id_t start_vertex,
                                               vertex_id_t end_vertex);
 

--- a/include/graaflib/algorithm/shortest_path.tpp
+++ b/include/graaflib/algorithm/shortest_path.tpp
@@ -10,9 +10,9 @@ namespace graaf::algorithm {
 
 namespace detail {
 
-template <typename V, typename E, edge_type T, graph_spec S>
+template <typename V, typename E, graph_spec S>
 std::optional<GraphPath<int>> get_unweighted_shortest_path(
-    const graph<V, E, T, S>& graph, vertex_id_t start_vertex,
+    const graph<V, E, S>& graph, vertex_id_t start_vertex,
     vertex_id_t end_vertex) {
   std::unordered_set<vertex_id_t> seen_vertices{};
   std::unordered_map<vertex_id_t, vertex_id_t> prev_vertex{};
@@ -63,9 +63,8 @@ std::optional<GraphPath<int>> get_unweighted_shortest_path(
 
 }  // namespace detail
 
-template <edge_strategy EDGE_STRATEGY, typename V, typename E, edge_type T,
-          graph_spec S>
-std::optional<GraphPath<E>> get_shortest_path(const graph<V, E, T, S>& graph,
+template <edge_strategy EDGE_STRATEGY, typename V, typename E, graph_spec S>
+std::optional<GraphPath<E>> get_shortest_path(const graph<V, E, S>& graph,
                                               vertex_id_t start_vertex,
                                               vertex_id_t end_vertex) {
   using enum edge_strategy;

--- a/include/graaflib/directed_graph.h
+++ b/include/graaflib/directed_graph.h
@@ -5,13 +5,11 @@
 
 namespace graaf {
 
-template <typename VERTEX_T, typename EDGE_T,
-          edge_type EDGE_TYPE_V = edge_type::UNWEIGHTED>
+template <typename VERTEX_T, typename EDGE_T>
 class directed_graph final
-    : public graph<VERTEX_T, EDGE_T, EDGE_TYPE_V, graph_spec::DIRECTED> {
+    : public graph<VERTEX_T, EDGE_T, graph_spec::DIRECTED> {
  private:
-  using edge_t =
-      graph<VERTEX_T, EDGE_T, EDGE_TYPE_V, graph_spec::DIRECTED>::edge_t;
+  using edge_t = graph<VERTEX_T, EDGE_T, graph_spec::DIRECTED>::edge_t;
 
   [[nodiscard]] bool do_has_edge(
       vertex_id_t vertex_id_lhs,

--- a/include/graaflib/directed_graph.tpp
+++ b/include/graaflib/directed_graph.tpp
@@ -2,29 +2,30 @@
 
 namespace graaf {
 
-template <typename VERTEX_T, typename EDGE_T, edge_type EDGE_TYPE_V>
-bool directed_graph<VERTEX_T, EDGE_T, EDGE_TYPE_V>::do_has_edge(
+template <typename VERTEX_T, typename EDGE_T>
+bool directed_graph<VERTEX_T, EDGE_T>::do_has_edge(
     vertex_id_t vertex_id_lhs, vertex_id_t vertex_id_rhs) const noexcept {
   return this->edges_.contains({vertex_id_lhs, vertex_id_rhs});
 }
 
-template <typename VERTEX_T, typename EDGE_T, edge_type EDGE_TYPE_V>
-directed_graph<VERTEX_T, EDGE_T, EDGE_TYPE_V>::edge_t&
-directed_graph<VERTEX_T, EDGE_T, EDGE_TYPE_V>::do_get_edge(
-    vertex_id_t vertex_id_lhs, vertex_id_t vertex_id_rhs) {
+template <typename VERTEX_T, typename EDGE_T>
+directed_graph<VERTEX_T, EDGE_T>::edge_t&
+directed_graph<VERTEX_T, EDGE_T>::do_get_edge(vertex_id_t vertex_id_lhs,
+                                              vertex_id_t vertex_id_rhs) {
   return this->edges_.at({vertex_id_lhs, vertex_id_rhs});
 }
 
-template <typename VERTEX_T, typename EDGE_T, edge_type EDGE_TYPE_V>
-void directed_graph<VERTEX_T, EDGE_T, EDGE_TYPE_V>::do_add_edge(
-    vertex_id_t vertex_id_lhs, vertex_id_t vertex_id_rhs, edge_t edge) {
+template <typename VERTEX_T, typename EDGE_T>
+void directed_graph<VERTEX_T, EDGE_T>::do_add_edge(vertex_id_t vertex_id_lhs,
+                                                   vertex_id_t vertex_id_rhs,
+                                                   edge_t edge) {
   this->adjacency_list_[vertex_id_lhs].insert(vertex_id_rhs);
   this->edges_.emplace(std::make_pair(vertex_id_lhs, vertex_id_rhs),
                        std::move(edge));
 }
 
-template <typename VERTEX_T, typename EDGE_T, edge_type EDGE_TYPE_V>
-void directed_graph<VERTEX_T, EDGE_T, EDGE_TYPE_V>::do_remove_edge(
+template <typename VERTEX_T, typename EDGE_T>
+void directed_graph<VERTEX_T, EDGE_T>::do_remove_edge(
     vertex_id_t vertex_id_lhs, vertex_id_t vertex_id_rhs) {
   this->adjacency_list_.at(vertex_id_lhs).erase(vertex_id_rhs);
   this->edges_.erase(std::make_pair(vertex_id_lhs, vertex_id_rhs));

--- a/include/graaflib/graph.h
+++ b/include/graaflib/graph.h
@@ -28,6 +28,13 @@ class graph {
  public:
   using vertex_t = VERTEX_T;
 
+  /**
+   * To provide a common interface for weighted edges, user provided edge
+   * classes can publically derive from weighted edge and optionally override
+   * the get_weight method. If a primitive numeric type is passes as the edge
+   * type, it is internally wrapped in a primitive_numeric_adapter, which
+   * derives from weighted_edge.
+   */
   using edge_t =
       std::conditional_t<detail::is_primitive_numeric_v<EDGE_T>,
                          std::shared_ptr<primitive_numeric_adapter<EDGE_T>>,
@@ -70,10 +77,25 @@ class graph {
    */
   [[nodiscard]] std::size_t edge_count() const noexcept;
 
+  /**
+   * @brief Get the intrnal vertices
+   *
+   * @return const vertex_id_to_vertex_t& Map from vertex id to the user
+   * provided vertex.
+   */
   [[nodiscard]] const vertex_id_to_vertex_t& get_vertices() const noexcept {
     return vertices_;
   }
 
+  /**
+   * @brief Get the internal edges
+   *
+   * One thing to not here is that edges are internally stored as shared
+   * pointers to either the user provided edge type or to
+   * primitive_numeric_adapter.
+   *
+   * @return const edge_id_to_edge_t& Map from edge id to edge_t.
+   */
   [[nodiscard]] const edge_id_to_edge_t& get_edges() const noexcept {
     return edges_;
   }
@@ -120,11 +142,12 @@ class graph {
   [[nodiscard]] const vertex_t& get_vertex(vertex_id_t vertex_id) const;
 
   /**
-   * Get edge between two vertices with theirs ID
+   * Get edge between two vertices with their ID
    *
    * @param  vertex_id_lhs The ID of the first vertex
    * @param  vertex_id_rhs The ID of the second vertex
-   * @return edge_t - A reference to edge
+   * @return edge_t - Shared pointer to either the provided edge or to
+   * primitive_numeric_adapter.
    * @throws out_of_range exception - If No edge exit between the two vertices
    */
   [[nodiscard]] edge_t& get_edge(vertex_id_t vertex_id_lhs,
@@ -137,7 +160,8 @@ class graph {
    * @see    graph#get_edge()
    * @param  vertex_id_lhs The ID of the first vertex
    * @param  vertex_id_rhs The ID of the second vertex
-   * @return edge_t - A const reference to the edge
+   * @return edge_t - Shared pointer to either the provided edge or to
+   * primitive_numeric_adapter.
    */
   [[nodiscard]] const edge_t& get_edge(vertex_id_t vertex_id_lhs,
                                        vertex_id_t vertex_id_rhs) const;

--- a/include/graaflib/graph.h
+++ b/include/graaflib/graph.h
@@ -12,35 +12,26 @@ namespace graaf {
 namespace detail {
 
 // Type trait to check if the type is a primitive numeric type
-template <typename T>
+template <typename EDGE_T>
 struct is_primitive_numeric;
 
-// Type trait to check if a type derives from weighted_edge
-template <typename T>
-struct is_weighted_edge;
+template <typename EDGE_T>
+inline constexpr bool is_primitive_numeric_v =
+    is_primitive_numeric<EDGE_T>::value;
 
 }  // namespace detail
 
-enum class edge_type { WEIGHTED, UNWEIGHTED };
 enum class graph_spec { DIRECTED, UNDIRECTED };
 
-template <typename VERTEX_T, typename EDGE_T, edge_type EDGE_TYPE_V,
-          graph_spec GRAPH_SPEC_V>
+template <typename VERTEX_T, typename EDGE_T, graph_spec GRAPH_SPEC_V>
 class graph {
-  using weighted_edge_t =
-      std::conditional_t<detail::is_primitive_numeric<EDGE_T>::value,
-                         std::shared_ptr<primitive_numeric_adapter<EDGE_T>>,
-                         std::shared_ptr<EDGE_T>>;
-
-  static_assert(EDGE_TYPE_V == edge_type::UNWEIGHTED ||
-                detail::is_weighted_edge<
-                    typename weighted_edge_t::element_type>::impl::value);
-
  public:
   using vertex_t = VERTEX_T;
 
-  using edge_t = std::conditional_t<EDGE_TYPE_V == edge_type::UNWEIGHTED,
-                                    EDGE_T, weighted_edge_t>;
+  using edge_t =
+      std::conditional_t<detail::is_primitive_numeric_v<EDGE_T>,
+                         std::shared_ptr<primitive_numeric_adapter<EDGE_T>>,
+                         std::shared_ptr<EDGE_T>>;
 
   using vertices_t = std::unordered_set<vertex_id_t>;
 
@@ -63,24 +54,6 @@ class graph {
    */
   [[nodiscard]] constexpr bool is_undirected() const {
     return GRAPH_SPEC_V == graph_spec::UNDIRECTED;
-  }
-
-  /**
-   * Checks whether the edges of a graph are weighted.
-   *
-   * @return bool
-   */
-  [[nodiscard]] constexpr bool is_weighted() const {
-    return EDGE_TYPE_V == edge_type::WEIGHTED;
-  }
-
-  /**
-   * Checks whether the edges of a graph are unweighted.
-   *
-   * @return bool
-   */
-  [[nodiscard]] constexpr bool is_unweighted() const {
-    return EDGE_TYPE_V == edge_type::UNWEIGHTED;
   }
 
   /**

--- a/include/graaflib/graph.tpp
+++ b/include/graaflib/graph.tpp
@@ -13,48 +13,33 @@ struct is_primitive_numeric
     : std::integral_constant<bool,
                              std::is_arithmetic_v<T> && !std::is_class_v<T>> {};
 
-std::false_type is_weighted_edge_impl(...);
-template <typename T>
-std::true_type is_weighted_edge_impl(weighted_edge<T>*);
-
-template <typename T>
-struct is_weighted_edge {
-  using impl = decltype(is_weighted_edge_impl(std::declval<T*>()));
-};
-
 }  // namespace detail
 
-template <typename VERTEX_T, typename EDGE_T, edge_type EDGE_TYPE_V,
-          graph_spec GRAPH_SPEC_V>
-std::size_t graph<VERTEX_T, EDGE_T, EDGE_TYPE_V, GRAPH_SPEC_V>::vertex_count()
+template <typename VERTEX_T, typename EDGE_T, graph_spec GRAPH_SPEC_V>
+std::size_t graph<VERTEX_T, EDGE_T, GRAPH_SPEC_V>::vertex_count()
     const noexcept {
   return vertices_.size();
 }
 
-template <typename VERTEX_T, typename EDGE_T, edge_type EDGE_TYPE_V,
-          graph_spec GRAPH_SPEC_V>
-std::size_t graph<VERTEX_T, EDGE_T, EDGE_TYPE_V, GRAPH_SPEC_V>::edge_count()
-    const noexcept {
+template <typename VERTEX_T, typename EDGE_T, graph_spec GRAPH_SPEC_V>
+std::size_t graph<VERTEX_T, EDGE_T, GRAPH_SPEC_V>::edge_count() const noexcept {
   return edges_.size();
 }
 
-template <typename VERTEX_T, typename EDGE_T, edge_type EDGE_TYPE_V,
-          graph_spec GRAPH_SPEC_V>
-bool graph<VERTEX_T, EDGE_T, EDGE_TYPE_V, GRAPH_SPEC_V>::has_vertex(
+template <typename VERTEX_T, typename EDGE_T, graph_spec GRAPH_SPEC_V>
+bool graph<VERTEX_T, EDGE_T, GRAPH_SPEC_V>::has_vertex(
     vertex_id_t vertex_id) const noexcept {
   return vertices_.contains(vertex_id);
 }
 
-template <typename VERTEX_T, typename EDGE_T, edge_type EDGE_TYPE_V,
-          graph_spec GRAPH_SPEC_V>
-bool graph<VERTEX_T, EDGE_T, EDGE_TYPE_V, GRAPH_SPEC_V>::has_edge(
+template <typename VERTEX_T, typename EDGE_T, graph_spec GRAPH_SPEC_V>
+bool graph<VERTEX_T, EDGE_T, GRAPH_SPEC_V>::has_edge(
     vertex_id_t vertex_id_lhs, vertex_id_t vertex_id_rhs) const noexcept {
   return do_has_edge(vertex_id_lhs, vertex_id_rhs);
 }
 
-template <typename VERTEX_T, typename EDGE_T, edge_type EDGE_TYPE_V,
-          graph_spec GRAPH_SPEC_V>
-VERTEX_T& graph<VERTEX_T, EDGE_T, EDGE_TYPE_V, GRAPH_SPEC_V>::get_vertex(
+template <typename VERTEX_T, typename EDGE_T, graph_spec GRAPH_SPEC_V>
+VERTEX_T& graph<VERTEX_T, EDGE_T, GRAPH_SPEC_V>::get_vertex(
     vertex_id_t vertex_id) {
   if (!has_vertex(vertex_id)) {
     throw std::out_of_range{
@@ -64,18 +49,16 @@ VERTEX_T& graph<VERTEX_T, EDGE_T, EDGE_TYPE_V, GRAPH_SPEC_V>::get_vertex(
   return vertices_.at(vertex_id);
 }
 
-template <typename VERTEX_T, typename EDGE_T, edge_type EDGE_TYPE_V,
-          graph_spec GRAPH_SPEC_V>
-const VERTEX_T& graph<VERTEX_T, EDGE_T, EDGE_TYPE_V, GRAPH_SPEC_V>::get_vertex(
+template <typename VERTEX_T, typename EDGE_T, graph_spec GRAPH_SPEC_V>
+const VERTEX_T& graph<VERTEX_T, EDGE_T, GRAPH_SPEC_V>::get_vertex(
     vertex_id_t vertex_id) const {
   return get_vertex(vertex_id);
 }
 
-template <typename VERTEX_T, typename EDGE_T, edge_type EDGE_TYPE_V,
-          graph_spec GRAPH_SPEC_V>
-graph<VERTEX_T, EDGE_T, EDGE_TYPE_V, GRAPH_SPEC_V>::edge_t&
-graph<VERTEX_T, EDGE_T, EDGE_TYPE_V, GRAPH_SPEC_V>::get_edge(
-    vertex_id_t vertex_id_lhs, vertex_id_t vertex_id_rhs) {
+template <typename VERTEX_T, typename EDGE_T, graph_spec GRAPH_SPEC_V>
+graph<VERTEX_T, EDGE_T, GRAPH_SPEC_V>::edge_t&
+graph<VERTEX_T, EDGE_T, GRAPH_SPEC_V>::get_edge(vertex_id_t vertex_id_lhs,
+                                                vertex_id_t vertex_id_rhs) {
   if (!has_edge(vertex_id_lhs, vertex_id_rhs)) {
     throw std::out_of_range{
         fmt::format("No edge found between vertices [{}] -> [{}].",
@@ -84,18 +67,16 @@ graph<VERTEX_T, EDGE_T, EDGE_TYPE_V, GRAPH_SPEC_V>::get_edge(
   return do_get_edge(vertex_id_lhs, vertex_id_rhs);
 }
 
-template <typename VERTEX_T, typename EDGE_T, edge_type EDGE_TYPE_V,
-          graph_spec GRAPH_SPEC_V>
-const graph<VERTEX_T, EDGE_T, EDGE_TYPE_V, GRAPH_SPEC_V>::edge_t&
-graph<VERTEX_T, EDGE_T, EDGE_TYPE_V, GRAPH_SPEC_V>::get_edge(
+template <typename VERTEX_T, typename EDGE_T, graph_spec GRAPH_SPEC_V>
+const graph<VERTEX_T, EDGE_T, GRAPH_SPEC_V>::edge_t&
+graph<VERTEX_T, EDGE_T, GRAPH_SPEC_V>::get_edge(
     vertex_id_t vertex_id_lhs, vertex_id_t vertex_id_rhs) const {
   return get_edge(vertex_id_lhs, vertex_id_rhs);
 }
 
-template <typename VERTEX_T, typename EDGE_T, edge_type EDGE_TYPE_V,
-          graph_spec GRAPH_SPEC_V>
-graph<VERTEX_T, EDGE_T, EDGE_TYPE_V, GRAPH_SPEC_V>::vertices_t
-graph<VERTEX_T, EDGE_T, EDGE_TYPE_V, GRAPH_SPEC_V>::get_neighbors(
+template <typename VERTEX_T, typename EDGE_T, graph_spec GRAPH_SPEC_V>
+graph<VERTEX_T, EDGE_T, GRAPH_SPEC_V>::vertices_t
+graph<VERTEX_T, EDGE_T, GRAPH_SPEC_V>::get_neighbors(
     vertex_id_t vertex_id) const {
   if (!adjacency_list_.contains(vertex_id)) {
     return {};
@@ -103,19 +84,16 @@ graph<VERTEX_T, EDGE_T, EDGE_TYPE_V, GRAPH_SPEC_V>::get_neighbors(
   return adjacency_list_.at(vertex_id);
 }
 
-template <typename VERTEX_T, typename EDGE_T, edge_type EDGE_TYPE_V,
-          graph_spec GRAPH_SPEC_V>
-vertex_id_t graph<VERTEX_T, EDGE_T, EDGE_TYPE_V, GRAPH_SPEC_V>::add_vertex(
-    VERTEX_T vertex) {
+template <typename VERTEX_T, typename EDGE_T, graph_spec GRAPH_SPEC_V>
+vertex_id_t graph<VERTEX_T, EDGE_T, GRAPH_SPEC_V>::add_vertex(VERTEX_T vertex) {
   // TODO: check overflow
   const auto vertex_id{vertex_id_supplier_++};
   vertices_.emplace(vertex_id, std::move(vertex));
   return vertex_id;
 }
 
-template <typename VERTEX_T, typename EDGE_T, edge_type EDGE_TYPE_V,
-          graph_spec GRAPH_SPEC_V>
-void graph<VERTEX_T, EDGE_T, EDGE_TYPE_V, GRAPH_SPEC_V>::remove_vertex(
+template <typename VERTEX_T, typename EDGE_T, graph_spec GRAPH_SPEC_V>
+void graph<VERTEX_T, EDGE_T, GRAPH_SPEC_V>::remove_vertex(
     vertex_id_t vertex_id) {
   if (adjacency_list_.contains(vertex_id)) {
     for (auto& target_vertex_id : adjacency_list_.at(vertex_id)) {
@@ -132,26 +110,21 @@ void graph<VERTEX_T, EDGE_T, EDGE_TYPE_V, GRAPH_SPEC_V>::remove_vertex(
   }
 }
 
-template <typename VERTEX_T, typename EDGE_T, edge_type EDGE_TYPE_V,
-          graph_spec GRAPH_SPEC_V>
-void graph<VERTEX_T, EDGE_T, EDGE_TYPE_V, GRAPH_SPEC_V>::add_edge(
-    vertex_id_t vertex_id_lhs, vertex_id_t vertex_id_rhs, EDGE_T edge) {
+template <typename VERTEX_T, typename EDGE_T, graph_spec GRAPH_SPEC_V>
+void graph<VERTEX_T, EDGE_T, GRAPH_SPEC_V>::add_edge(vertex_id_t vertex_id_lhs,
+                                                     vertex_id_t vertex_id_rhs,
+                                                     EDGE_T edge) {
   if (!has_vertex(vertex_id_lhs) || !has_vertex(vertex_id_rhs)) {
     throw std::out_of_range{
         fmt::format("Vertices with ID [{}] and [{}] not found in graph.",
                     vertex_id_lhs, vertex_id_rhs)};
   }
-  if constexpr (EDGE_TYPE_V == edge_type::WEIGHTED) {
-    do_add_edge(vertex_id_lhs, vertex_id_rhs,
-                std::make_shared<typename edge_t::element_type>(edge));
-  } else {
-    do_add_edge(vertex_id_lhs, vertex_id_rhs, edge);
-  }
+  do_add_edge(vertex_id_lhs, vertex_id_rhs,
+              std::make_shared<typename edge_t::element_type>(edge));
 }
 
-template <typename VERTEX_T, typename EDGE_T, edge_type EDGE_TYPE_V,
-          graph_spec GRAPH_SPEC_V>
-void graph<VERTEX_T, EDGE_T, EDGE_TYPE_V, GRAPH_SPEC_V>::remove_edge(
+template <typename VERTEX_T, typename EDGE_T, graph_spec GRAPH_SPEC_V>
+void graph<VERTEX_T, EDGE_T, GRAPH_SPEC_V>::remove_edge(
     vertex_id_t vertex_id_lhs, vertex_id_t vertex_id_rhs) {
   do_remove_edge(vertex_id_lhs, vertex_id_rhs);
 }

--- a/include/graaflib/io/dot.h
+++ b/include/graaflib/io/dot.h
@@ -21,11 +21,9 @@ const auto default_vertex_writer{
       return fmt::format("label=\"{}: {}\"", vertex_id, std::to_string(vertex));
     }};
 
-template <typename T>
-  requires string_convertible<T>
 const auto default_edge_writer{
-    [](const edge_id_t& /*edge_id*/, const T& edge) -> std::string {
-      return fmt::format("label=\"{}\"", std::to_string(edge));
+    [](const edge_id_t& /*edge_id*/, const auto& edge) -> std::string {
+      return fmt::format("label=\"{}\"", std::to_string(edge->get_weight()));
     }};
 }  // namespace detail
 
@@ -39,21 +37,22 @@ const auto default_edge_writer{
  * accept a vertex_id_t and a type V and serialize it to a string. Default
  * implementations are provided for primitive numeric types.
  * @param edge_writer Function used for serializing the edges. Should accept an
- * edge_id_t and a type E and serialize it to a string. Default implementations
- * are provided for primitive numeric types.
+ * edge_id_t and a graph::edge_t and serialize it to a string. Default
+ * implementations are provided for primitive numeric types.
  * @param path Path to the output dot file.
  */
-template <typename V, typename E, edge_type T, graph_spec S,
+template <typename V, typename E, graph_spec S,
           typename VERTEX_WRITER_T = decltype(detail::default_vertex_writer<V>),
-          typename EDGE_WRITER_T = decltype(detail::default_edge_writer<E>)>
+          typename EDGE_WRITER_T = decltype(detail::default_edge_writer)>
   requires std::is_invocable_r_v<std::string, const VERTEX_WRITER_T&,
                                  vertex_id_t, const V&> &&
            std::is_invocable_r_v<std::string, const EDGE_WRITER_T&,
-                                 const graaf::edge_id_t&, const E&>
+                                 const graaf::edge_id_t&,
+                                 const typename graph<V, E, S>::edge_t&>
 void to_dot(
-    const graph<V, E, T, S>& graph, const std::filesystem::path& path,
+    const graph<V, E, S>& graph, const std::filesystem::path& path,
     const VERTEX_WRITER_T& vertex_writer = detail::default_vertex_writer<V>,
-    const EDGE_WRITER_T& edge_writer = detail::default_edge_writer<E>);
+    const EDGE_WRITER_T& edge_writer = detail::default_edge_writer);
 
 }  // namespace graaf::io
 

--- a/include/graaflib/io/dot.tpp
+++ b/include/graaflib/io/dot.tpp
@@ -63,13 +63,14 @@ constexpr const char* spec_to_edge_specifier(const graph_spec& spec) {
 }
 }  // namespace detail
 
-template <typename V, typename E, edge_type T, graph_spec S,
-          typename VERTEX_WRITER_T, typename EDGE_WRITER_T>
+template <typename V, typename E, graph_spec S, typename VERTEX_WRITER_T,
+          typename EDGE_WRITER_T>
   requires std::is_invocable_r_v<std::string, const VERTEX_WRITER_T&,
                                  vertex_id_t, const V&> &&
            std::is_invocable_r_v<std::string, const EDGE_WRITER_T&,
-                                 const graaf::edge_id_t&, const E&>
-void to_dot(const graph<V, E, T, S>& graph, const std::filesystem::path& path,
+                                 const graaf::edge_id_t&,
+                                 const typename graph<V, E, S>::edge_t&>
+void to_dot(const graph<V, E, S>& graph, const std::filesystem::path& path,
             const VERTEX_WRITER_T& vertex_writer,
             const EDGE_WRITER_T& edge_writer) {
   std::ofstream dot_file{path};

--- a/include/graaflib/properties/vertex_properties.h
+++ b/include/graaflib/properties/vertex_properties.h
@@ -5,17 +5,17 @@
 
 namespace graaf::properties {
 
-template <typename V, typename E, edge_type T, graph_spec S>
-[[nodiscard]] std::size_t get_vertex_degree(
-    const graaf::graph<V, E, T, S>& graph, vertex_id_t vertex_id);
+template <typename V, typename E, graph_spec S>
+[[nodiscard]] std::size_t get_vertex_degree(const graaf::graph<V, E, S>& graph,
+                                            vertex_id_t vertex_id);
 
-template <typename V, typename E, edge_type T, graph_spec S>
+template <typename V, typename E, graph_spec S>
 [[nodiscard]] std::size_t get_vertex_outdegree(
-    const graaf::graph<V, E, T, S>& graph, vertex_id_t vertex_id);
+    const graaf::graph<V, E, S>& graph, vertex_id_t vertex_id);
 
-template <typename V, typename E, edge_type T, graph_spec S>
+template <typename V, typename E, graph_spec S>
 [[nodiscard]] std::size_t get_vertex_indegree(
-    const graaf::graph<V, E, T, S>& graph, vertex_id_t vertex_id);
+    const graaf::graph<V, E, S>& graph, vertex_id_t vertex_id);
 
 }  // namespace graaf::properties
 

--- a/include/graaflib/properties/vertex_properties.tpp
+++ b/include/graaflib/properties/vertex_properties.tpp
@@ -4,8 +4,8 @@
 
 namespace graaf::properties {
 
-template <typename V, typename E, edge_type T, graph_spec S>
-std::size_t get_vertex_degree(const graaf::graph<V, E, T, S>& graph,
+template <typename V, typename E, graph_spec S>
+std::size_t get_vertex_degree(const graaf::graph<V, E, S>& graph,
                               vertex_id_t vertex_id) {
   if constexpr (S == graph_spec::DIRECTED) {
     return get_vertex_outdegree(graph, vertex_id) +
@@ -20,14 +20,14 @@ std::size_t get_vertex_degree(const graaf::graph<V, E, T, S>& graph,
   std::abort();
 }
 
-template <typename V, typename E, edge_type T, graph_spec S>
-std::size_t get_vertex_outdegree(const graaf::graph<V, E, T, S>& graph,
+template <typename V, typename E, graph_spec S>
+std::size_t get_vertex_outdegree(const graaf::graph<V, E, S>& graph,
                                  vertex_id_t vertex_id) {
   return (graph.get_neighbors(vertex_id)).size();
 }
 
-template <typename V, typename E, edge_type T, graph_spec S>
-std::size_t get_vertex_indegree(const graaf::graph<V, E, T, S>& graph,
+template <typename V, typename E, graph_spec S>
+std::size_t get_vertex_indegree(const graaf::graph<V, E, S>& graph,
                                 vertex_id_t vertex_id) {
   using vertex_id_to_vertex_t = std::unordered_map<vertex_id_t, V>;
 

--- a/include/graaflib/types.h
+++ b/include/graaflib/types.h
@@ -31,6 +31,7 @@ struct edge_id_hash {
 template <typename WEIGHT_T = int>
 class weighted_edge {
  public:
+  using weight_t = WEIGHT_T;
   /**
    * By default an edge has a unit weight.
    */

--- a/include/graaflib/types.h
+++ b/include/graaflib/types.h
@@ -28,10 +28,13 @@ struct edge_id_hash {
  *
  * @tparam WEIGHT_T The type of the weight.
  */
-template <typename WEIGHT_T>
+template <typename WEIGHT_T = int>
 class weighted_edge {
  public:
-  [[nodiscard]] virtual WEIGHT_T get_weight() const noexcept = 0;
+  /**
+   * By default an edge has a unit weight.
+   */
+  [[nodiscard]] virtual WEIGHT_T get_weight() const noexcept { return 1; };
 };
 
 /**

--- a/include/graaflib/undirected_graph.h
+++ b/include/graaflib/undirected_graph.h
@@ -5,13 +5,11 @@
 
 namespace graaf {
 
-template <typename VERTEX_T, typename EDGE_T,
-          edge_type EDGE_TYPE_V = edge_type::UNWEIGHTED>
+template <typename VERTEX_T, typename EDGE_T>
 class undirected_graph final
-    : public graph<VERTEX_T, EDGE_T, EDGE_TYPE_V, graph_spec::UNDIRECTED> {
+    : public graph<VERTEX_T, EDGE_T, graph_spec::UNDIRECTED> {
  private:
-  using edge_t =
-      graph<VERTEX_T, EDGE_T, EDGE_TYPE_V, graph_spec::UNDIRECTED>::edge_t;
+  using edge_t = graph<VERTEX_T, EDGE_T, graph_spec::UNDIRECTED>::edge_t;
 
   [[nodiscard]] bool do_has_edge(
       vertex_id_t vertex_id_lhs,

--- a/include/graaflib/undirected_graph.tpp
+++ b/include/graaflib/undirected_graph.tpp
@@ -12,24 +12,25 @@ inline std::pair<vertex_id_t, vertex_id_t> make_sorted_pair(
 }
 }  // namespace detail
 
-template <typename VERTEX_T, typename EDGE_T, edge_type EDGE_TYPE_V>
-bool undirected_graph<VERTEX_T, EDGE_T, EDGE_TYPE_V>::do_has_edge(
+template <typename VERTEX_T, typename EDGE_T>
+bool undirected_graph<VERTEX_T, EDGE_T>::do_has_edge(
     vertex_id_t vertex_id_lhs, vertex_id_t vertex_id_rhs) const noexcept {
   return this->edges_.contains(
       detail::make_sorted_pair(vertex_id_lhs, vertex_id_rhs));
 }
 
-template <typename VERTEX_T, typename EDGE_T, edge_type EDGE_TYPE_V>
-undirected_graph<VERTEX_T, EDGE_T, EDGE_TYPE_V>::edge_t&
-undirected_graph<VERTEX_T, EDGE_T, EDGE_TYPE_V>::do_get_edge(
-    vertex_id_t vertex_id_lhs, vertex_id_t vertex_id_rhs) {
+template <typename VERTEX_T, typename EDGE_T>
+undirected_graph<VERTEX_T, EDGE_T>::edge_t&
+undirected_graph<VERTEX_T, EDGE_T>::do_get_edge(vertex_id_t vertex_id_lhs,
+                                                vertex_id_t vertex_id_rhs) {
   return this->edges_.at(
       detail::make_sorted_pair(vertex_id_lhs, vertex_id_rhs));
 }
 
-template <typename VERTEX_T, typename EDGE_T, edge_type EDGE_TYPE_V>
-void undirected_graph<VERTEX_T, EDGE_T, EDGE_TYPE_V>::do_add_edge(
-    vertex_id_t vertex_id_lhs, vertex_id_t vertex_id_rhs, edge_t edge) {
+template <typename VERTEX_T, typename EDGE_T>
+void undirected_graph<VERTEX_T, EDGE_T>::do_add_edge(vertex_id_t vertex_id_lhs,
+                                                     vertex_id_t vertex_id_rhs,
+                                                     edge_t edge) {
   this->adjacency_list_[vertex_id_lhs].insert(vertex_id_rhs);
   this->adjacency_list_[vertex_id_rhs].insert(vertex_id_lhs);
 
@@ -37,8 +38,8 @@ void undirected_graph<VERTEX_T, EDGE_T, EDGE_TYPE_V>::do_add_edge(
                        std::move(edge));
 }
 
-template <typename VERTEX_T, typename EDGE_T, edge_type EDGE_TYPE_V>
-void undirected_graph<VERTEX_T, EDGE_T, EDGE_TYPE_V>::do_remove_edge(
+template <typename VERTEX_T, typename EDGE_T>
+void undirected_graph<VERTEX_T, EDGE_T>::do_remove_edge(
     vertex_id_t vertex_id_lhs, vertex_id_t vertex_id_rhs) {
   this->adjacency_list_.at(vertex_id_lhs).erase(vertex_id_rhs);
   this->adjacency_list_.at(vertex_id_rhs).erase(vertex_id_lhs);

--- a/test/graaflib/directed_graph_test.cpp
+++ b/test/graaflib/directed_graph_test.cpp
@@ -27,7 +27,7 @@ TEST(DirectedGraphTest, EdgeCount) {
   ASSERT_EQ(graph.edge_count(), 1);
   ASSERT_TRUE(graph.has_edge(vertex_id_1, vertex_id_2));
   ASSERT_FALSE(graph.has_edge(vertex_id_2, vertex_id_1));
-  ASSERT_EQ(graph.get_edge(vertex_id_1, vertex_id_2), 100);
+  ASSERT_EQ(graph.get_edge(vertex_id_1, vertex_id_2)->get_weight(), 100);
 }
 
 TEST(DirectedGraphTest, GetNeighbors) {

--- a/test/graaflib/graph_test.cpp
+++ b/test/graaflib/graph_test.cpp
@@ -16,10 +16,8 @@ struct GraphTest : public testing::Test {
 };
 
 using graph_types =
-    testing::Types<directed_graph<int, int>,
-                   directed_graph<int, int, edge_type::WEIGHTED>,
-                   undirected_graph<int, int>,
-                   undirected_graph<int, int, edge_type::WEIGHTED>>;
+    testing::Types<directed_graph<int, int>, directed_graph<int, int>,
+                   undirected_graph<int, int>, undirected_graph<int, int>>;
 
 TYPED_TEST_CASE(GraphTest, graph_types);
 

--- a/test/graaflib/graph_traits_test.cpp
+++ b/test/graaflib/graph_traits_test.cpp
@@ -8,33 +8,16 @@ namespace graaf {
  * DIRECTED GRAPH
  */
 
-TEST(GraphTraitsTest, DirectedGraphUnweightedPrimitiveType) {
+TEST(GraphTraitsTest, DirectedGraphPrimitiveType) {
   // GIVEN - WHEN
   directed_graph<int, int> graph{};
 
   // THEN The graph is directed
   ASSERT_TRUE(graph.is_directed());
   ASSERT_FALSE(graph.is_undirected());
-
-  // By default the graph is unweighted
-  ASSERT_TRUE(graph.is_unweighted());
-  ASSERT_FALSE(graph.is_weighted());
 }
 
-TEST(GraphTraitsTest, DirectedGraphWeightedPrimitiveType) {
-  // GIVEN - WHEN
-  directed_graph<int, int, edge_type::WEIGHTED> graph{};
-
-  // THEN The graph is directed
-  ASSERT_TRUE(graph.is_directed());
-  ASSERT_FALSE(graph.is_undirected());
-
-  // The graph is weighted
-  ASSERT_TRUE(graph.is_weighted());
-  ASSERT_FALSE(graph.is_unweighted());
-}
-
-TEST(GraphTraitsTest, DirectedGraphUnweightedPNonrimitiveType) {
+TEST(GraphTraitsTest, DirectedGraphNonPrimitiveType) {
   // GIVEN - WHEN
   struct my_edge {};
 
@@ -43,58 +26,22 @@ TEST(GraphTraitsTest, DirectedGraphUnweightedPNonrimitiveType) {
   // THEN The graph is directed
   ASSERT_TRUE(graph.is_directed());
   ASSERT_FALSE(graph.is_undirected());
-
-  // By default the graph is unweighted
-  ASSERT_TRUE(graph.is_unweighted());
-  ASSERT_FALSE(graph.is_weighted());
-}
-
-TEST(GraphTraitsTest, DirectedGraphWeightedNonPrimitiveType) {
-  // GIVEN - WHEN
-  struct my_edge : public weighted_edge<int> {};
-
-  directed_graph<int, my_edge, edge_type::WEIGHTED> graph{};
-
-  // THEN The graph is directed
-  ASSERT_TRUE(graph.is_directed());
-  ASSERT_FALSE(graph.is_undirected());
-
-  // The graph is weighted
-  ASSERT_TRUE(graph.is_weighted());
-  ASSERT_FALSE(graph.is_unweighted());
 }
 
 /**
  * UNDIRECTED GRAPH
  */
 
-TEST(GraphTraitsTest, UndirectedGraphUnweightedPrimitiveType) {
+TEST(GraphTraitsTest, UndirectedGraphPrimitiveType) {
   // GIVEN - WHEN
   undirected_graph<int, int> graph{};
 
   // THEN The graph is undirected
   ASSERT_TRUE(graph.is_undirected());
   ASSERT_FALSE(graph.is_directed());
-
-  // By default the graph is unweighted
-  ASSERT_TRUE(graph.is_unweighted());
-  ASSERT_FALSE(graph.is_weighted());
 }
 
-TEST(GraphTraitsTest, UndirectedGraphWeightedPrimitiveType) {
-  // GIVEN - WHEN
-  undirected_graph<int, int, edge_type::WEIGHTED> graph{};
-
-  // THEN The graph is undirected
-  ASSERT_TRUE(graph.is_undirected());
-  ASSERT_FALSE(graph.is_directed());
-
-  // The graph is weighted
-  ASSERT_TRUE(graph.is_weighted());
-  ASSERT_FALSE(graph.is_unweighted());
-}
-
-TEST(GraphTraitsTest, UndirectedGraphUnweightedPNonrimitiveType) {
+TEST(GraphTraitsTest, UndirectedGraphNonPrimitiveType) {
   // GIVEN - WHEN
   struct my_edge {};
 
@@ -103,25 +50,6 @@ TEST(GraphTraitsTest, UndirectedGraphUnweightedPNonrimitiveType) {
   // THEN The graph is undirected
   ASSERT_TRUE(graph.is_undirected());
   ASSERT_FALSE(graph.is_directed());
-
-  // By default the graph is unweighted
-  ASSERT_TRUE(graph.is_unweighted());
-  ASSERT_FALSE(graph.is_weighted());
-}
-
-TEST(GraphTraitsTest, UndirectedGraphWeightedNonPrimitiveType) {
-  // GIVEN - WHEN
-  struct my_edge : public weighted_edge<int> {};
-
-  undirected_graph<int, my_edge, edge_type::WEIGHTED> graph{};
-
-  // THEN The graph is undirected
-  ASSERT_TRUE(graph.is_undirected());
-  ASSERT_FALSE(graph.is_directed());
-
-  // The graph is weighted
-  ASSERT_TRUE(graph.is_weighted());
-  ASSERT_FALSE(graph.is_unweighted());
 }
 
 }  // namespace graaf

--- a/test/graaflib/io/dot_test.cpp
+++ b/test/graaflib/io/dot_test.cpp
@@ -20,8 +20,8 @@ const auto int_vertex_writer{
     }};
 
 const auto int_edge_writer{
-    [](const edge_id_t& /*edge_id*/, int edge) -> std::string {
-      return fmt::format("label=\"{}\"", std::to_string(edge));
+    [](const edge_id_t& /*edge_id*/, const auto& edge) -> std::string {
+      return fmt::format("label=\"{}\"", std::to_string(edge->get_weight()));
     }};
 
 template <typename T>
@@ -210,8 +210,8 @@ TEST(DotTest, UserProvidedVertexAndEdgeClass) {
       [](vertex_id_t /*vertex_id*/, const vertex_t& vertex) {
         return fmt::format("{}, {}", vertex.numeric_data, vertex.string_data);
       }};
-  const auto edge_writer{[](const edge_id_t& /*edge_id*/, const edge_t& edge) {
-    return fmt::format("{}, {}", edge.numeric_data, edge.string_data);
+  const auto edge_writer{[](const edge_id_t& /*edge_id*/, const auto& edge) {
+    return fmt::format("{}, {}", edge->numeric_data, edge->string_data);
   }};
 
   // WHEN

--- a/test/graaflib/undirected_graph_test.cpp
+++ b/test/graaflib/undirected_graph_test.cpp
@@ -27,7 +27,7 @@ TEST(UndirectedGraphTest, EdgeCount) {
   ASSERT_EQ(graph.edge_count(), 1);
   ASSERT_TRUE(graph.has_edge(vertex_id_1, vertex_id_2));
   ASSERT_TRUE(graph.has_edge(vertex_id_2, vertex_id_1));
-  ASSERT_EQ(graph.get_edge(vertex_id_1, vertex_id_2), 100);
+  ASSERT_EQ(graph.get_edge(vertex_id_1, vertex_id_2)->get_weight(), 100);
 }
 
 TEST(UndirectedGraphTest, GetNeighbors) {

--- a/test/graaflib/weighted_graph_test.cpp
+++ b/test/graaflib/weighted_graph_test.cpp
@@ -7,12 +7,10 @@
 
 namespace graaf {
 
-// TODO: push this into the base class
 template <typename T>
-class my_edge : public weighted_edge<T> {
+class my_weighted_edge : public weighted_edge<T> {
  public:
-  using type = T;
-  explicit my_edge(T weight) : weight_{weight} {}
+  explicit my_weighted_edge(T weight) : weight_{weight} {}
 
   [[nodiscard]] T get_weight() const noexcept override { return weight_; }
 
@@ -26,7 +24,7 @@ struct WeightedGraphTest : public testing::Test {
   using edge_t = T::second_type;
 };
 
-using graph_types = testing::Types<
+using weighted_graph_types = testing::Types<
 
     /**
      * Primitive edge type directed graph
@@ -38,14 +36,18 @@ using graph_types = testing::Types<
     std::pair<directed_graph<int, long double>, long double>,
 
     /**
-     * Non primitive edge type directed graph
+     * Non primitive weighted edge type directed graph
      */
-    std::pair<directed_graph<int, my_edge<bool>>, my_edge<bool>>,
-    std::pair<directed_graph<int, my_edge<int>>, my_edge<int>>,
-    std::pair<directed_graph<int, my_edge<unsigned long>>,
-              my_edge<unsigned long>>,
-    std::pair<directed_graph<int, my_edge<float>>, my_edge<float>>,
-    std::pair<directed_graph<int, my_edge<long double>>, my_edge<long double>>,
+    std::pair<directed_graph<int, my_weighted_edge<bool>>,
+              my_weighted_edge<bool>>,
+    std::pair<directed_graph<int, my_weighted_edge<int>>,
+              my_weighted_edge<int>>,
+    std::pair<directed_graph<int, my_weighted_edge<unsigned long>>,
+              my_weighted_edge<unsigned long>>,
+    std::pair<directed_graph<int, my_weighted_edge<float>>,
+              my_weighted_edge<float>>,
+    std::pair<directed_graph<int, my_weighted_edge<long double>>,
+              my_weighted_edge<long double>>,
 
     /**
      * Primitive edge type undirected graph
@@ -57,17 +59,20 @@ using graph_types = testing::Types<
     std::pair<undirected_graph<int, long double>, long double>,
 
     /**
-     * Non primitive edge type undirected graph
+     * Non primitive weighted edge type undirected graph
      */
-    std::pair<undirected_graph<int, my_edge<bool>>, my_edge<bool>>,
-    std::pair<undirected_graph<int, my_edge<int>>, my_edge<int>>,
-    std::pair<undirected_graph<int, my_edge<unsigned long>>,
-              my_edge<unsigned long>>,
-    std::pair<undirected_graph<int, my_edge<float>>, my_edge<float>>,
-    std::pair<undirected_graph<int, my_edge<long double>>,
-              my_edge<long double>>>;
+    std::pair<undirected_graph<int, my_weighted_edge<bool>>,
+              my_weighted_edge<bool>>,
+    std::pair<undirected_graph<int, my_weighted_edge<int>>,
+              my_weighted_edge<int>>,
+    std::pair<undirected_graph<int, my_weighted_edge<unsigned long>>,
+              my_weighted_edge<unsigned long>>,
+    std::pair<undirected_graph<int, my_weighted_edge<float>>,
+              my_weighted_edge<float>>,
+    std::pair<undirected_graph<int, my_weighted_edge<long double>>,
+              my_weighted_edge<long double>>>;
 
-TYPED_TEST_CASE(WeightedGraphTest, graph_types);
+TYPED_TEST_CASE(WeightedGraphTest, weighted_graph_types);
 
 // Type traits to extract the weight type from both classes and primitives
 template <typename T>
@@ -76,9 +81,9 @@ struct extract_weight {
 };
 
 template <typename T>
-  requires requires { typename T::type; }
+  requires requires { typename T::weight_t; }
 struct extract_weight<T> {
-  using type = typename T::type;
+  using type = typename T::weight_t;
 };
 
 TYPED_TEST(WeightedGraphTest, AddWeightedEdge) {
@@ -99,6 +104,73 @@ TYPED_TEST(WeightedGraphTest, AddWeightedEdge) {
   ASSERT_TRUE(graph.has_edge(vertex_id_1, vertex_id_2));
   ASSERT_EQ(graph.get_edge(vertex_id_1, vertex_id_2)->get_weight(),
             static_cast<weight_t>(3));
+}
+
+/**
+ * We do not override the virtual get_weight method such that each edge has a
+ * unit weight.
+ */
+template <typename T>
+class my_unit_weighted_edge : public weighted_edge<T> {};
+
+template <typename T>
+struct UnitWeightedGraphTest : public testing::Test {
+  using graph_t = T::first_type;
+  using edge_t = T::second_type;
+};
+
+using unit_weighted_graph_types = testing::Types<
+
+    /**
+     * Unit weighted edge type directed graph
+     */
+    std::pair<directed_graph<int, my_unit_weighted_edge<bool>>,
+              my_unit_weighted_edge<bool>>,
+    std::pair<directed_graph<int, my_unit_weighted_edge<int>>,
+              my_unit_weighted_edge<int>>,
+    std::pair<directed_graph<int, my_unit_weighted_edge<unsigned long>>,
+              my_unit_weighted_edge<unsigned long>>,
+    std::pair<directed_graph<int, my_unit_weighted_edge<float>>,
+              my_unit_weighted_edge<float>>,
+    std::pair<directed_graph<int, my_unit_weighted_edge<long double>>,
+              my_unit_weighted_edge<long double>>,
+
+    /**
+     * Unit weighted edge type undirected graph
+     */
+    std::pair<undirected_graph<int, my_unit_weighted_edge<bool>>,
+              my_unit_weighted_edge<bool>>,
+    std::pair<undirected_graph<int, my_unit_weighted_edge<int>>,
+              my_unit_weighted_edge<int>>,
+    std::pair<undirected_graph<int, my_unit_weighted_edge<unsigned long>>,
+              my_unit_weighted_edge<unsigned long>>,
+    std::pair<undirected_graph<int, my_unit_weighted_edge<float>>,
+              my_unit_weighted_edge<float>>,
+    std::pair<undirected_graph<int, my_unit_weighted_edge<long double>>,
+              my_unit_weighted_edge<long double>>>;
+
+TYPED_TEST_CASE(UnitWeightedGraphTest, unit_weighted_graph_types);
+
+TYPED_TEST(UnitWeightedGraphTest, AddUnitWeightedEdge) {
+  // GIVEN
+  using graph_t = typename TestFixture::graph_t;
+  using edge_t = typename TestFixture::edge_t;
+  using weight_t = extract_weight<edge_t>::type;
+
+  graph_t graph{};
+
+  const auto vertex_id_1{graph.add_vertex(10)};
+  const auto vertex_id_2{graph.add_vertex(20)};
+
+  // WHEN
+  graph.add_edge(vertex_id_1, vertex_id_2, edge_t{});
+
+  // THEN
+  ASSERT_TRUE(graph.has_edge(vertex_id_1, vertex_id_2));
+
+  // By default each edge has a unit weight
+  ASSERT_EQ(graph.get_edge(vertex_id_1, vertex_id_2)->get_weight(),
+            static_cast<weight_t>(1));
 }
 
 }  // namespace graaf

--- a/test/graaflib/weighted_graph_test.cpp
+++ b/test/graaflib/weighted_graph_test.cpp
@@ -7,6 +7,7 @@
 
 namespace graaf {
 
+// TODO: push this into the base class
 template <typename T>
 class my_edge : public weighted_edge<T> {
  public:
@@ -30,52 +31,40 @@ using graph_types = testing::Types<
     /**
      * Primitive edge type directed graph
      */
-    std::pair<directed_graph<int, bool, edge_type::WEIGHTED>, bool>,
-    std::pair<directed_graph<int, int, edge_type::WEIGHTED>, int>,
-    std::pair<directed_graph<int, unsigned long, edge_type::WEIGHTED>,
-              unsigned long>,
-    std::pair<directed_graph<int, float, edge_type::WEIGHTED>, float>,
-    std::pair<directed_graph<int, long double, edge_type::WEIGHTED>,
-              long double>,
+    std::pair<directed_graph<int, bool>, bool>,
+    std::pair<directed_graph<int, int>, int>,
+    std::pair<directed_graph<int, unsigned long>, unsigned long>,
+    std::pair<directed_graph<int, float>, float>,
+    std::pair<directed_graph<int, long double>, long double>,
 
     /**
      * Non primitive edge type directed graph
      */
-    std::pair<directed_graph<int, my_edge<bool>, edge_type::WEIGHTED>,
-              my_edge<bool>>,
-    std::pair<directed_graph<int, my_edge<int>, edge_type::WEIGHTED>,
-              my_edge<int>>,
-    std::pair<directed_graph<int, my_edge<unsigned long>, edge_type::WEIGHTED>,
+    std::pair<directed_graph<int, my_edge<bool>>, my_edge<bool>>,
+    std::pair<directed_graph<int, my_edge<int>>, my_edge<int>>,
+    std::pair<directed_graph<int, my_edge<unsigned long>>,
               my_edge<unsigned long>>,
-    std::pair<directed_graph<int, my_edge<float>, edge_type::WEIGHTED>,
-              my_edge<float>>,
-    std::pair<directed_graph<int, my_edge<long double>, edge_type::WEIGHTED>,
-              my_edge<long double>>,
+    std::pair<directed_graph<int, my_edge<float>>, my_edge<float>>,
+    std::pair<directed_graph<int, my_edge<long double>>, my_edge<long double>>,
 
     /**
      * Primitive edge type undirected graph
      */
-    std::pair<undirected_graph<int, bool, edge_type::WEIGHTED>, bool>,
-    std::pair<undirected_graph<int, int, edge_type::WEIGHTED>, int>,
-    std::pair<undirected_graph<int, unsigned long, edge_type::WEIGHTED>,
-              unsigned long>,
-    std::pair<undirected_graph<int, float, edge_type::WEIGHTED>, float>,
-    std::pair<undirected_graph<int, long double, edge_type::WEIGHTED>,
-              long double>,
+    std::pair<undirected_graph<int, bool>, bool>,
+    std::pair<undirected_graph<int, int>, int>,
+    std::pair<undirected_graph<int, unsigned long>, unsigned long>,
+    std::pair<undirected_graph<int, float>, float>,
+    std::pair<undirected_graph<int, long double>, long double>,
 
     /**
      * Non primitive edge type undirected graph
      */
-    std::pair<undirected_graph<int, my_edge<bool>, edge_type::WEIGHTED>,
-              my_edge<bool>>,
-    std::pair<undirected_graph<int, my_edge<int>, edge_type::WEIGHTED>,
-              my_edge<int>>,
-    std::pair<
-        undirected_graph<int, my_edge<unsigned long>, edge_type::WEIGHTED>,
-        my_edge<unsigned long>>,
-    std::pair<undirected_graph<int, my_edge<float>, edge_type::WEIGHTED>,
-              my_edge<float>>,
-    std::pair<undirected_graph<int, my_edge<long double>, edge_type::WEIGHTED>,
+    std::pair<undirected_graph<int, my_edge<bool>>, my_edge<bool>>,
+    std::pair<undirected_graph<int, my_edge<int>>, my_edge<int>>,
+    std::pair<undirected_graph<int, my_edge<unsigned long>>,
+              my_edge<unsigned long>>,
+    std::pair<undirected_graph<int, my_edge<float>>, my_edge<float>>,
+    std::pair<undirected_graph<int, my_edge<long double>>,
               my_edge<long double>>>;
 
 TYPED_TEST_CASE(WeightedGraphTest, graph_types);

--- a/test/graaflib/weighted_graph_test.cpp
+++ b/test/graaflib/weighted_graph_test.cpp
@@ -173,4 +173,74 @@ TYPED_TEST(UnitWeightedGraphTest, AddUnitWeightedEdge) {
             static_cast<weight_t>(1));
 }
 
+/**
+ * We do not derive from weighted edge, so we do not have the default provided
+ * get_weight method.
+ */
+template <typename T>
+struct my_unweighted_edge {
+  using weight_t = T;
+  T val{};
+};
+
+template <typename T>
+struct UnweightedGraphTest : public testing::Test {
+  using graph_t = T::first_type;
+  using edge_t = T::second_type;
+};
+
+using unweighted_graph_types = testing::Types<
+
+    /**
+     * Unweighted edge type directed graph
+     */
+    std::pair<directed_graph<int, my_unweighted_edge<bool>>,
+              my_unweighted_edge<bool>>,
+    std::pair<directed_graph<int, my_unweighted_edge<int>>,
+              my_unweighted_edge<int>>,
+    std::pair<directed_graph<int, my_unweighted_edge<unsigned long>>,
+              my_unweighted_edge<unsigned long>>,
+    std::pair<directed_graph<int, my_unweighted_edge<float>>,
+              my_unweighted_edge<float>>,
+    std::pair<directed_graph<int, my_unweighted_edge<long double>>,
+              my_unweighted_edge<long double>>,
+
+    /**
+     * Unweighted edge type undirected graph
+     */
+    std::pair<undirected_graph<int, my_unweighted_edge<bool>>,
+              my_unweighted_edge<bool>>,
+    std::pair<undirected_graph<int, my_unweighted_edge<int>>,
+              my_unweighted_edge<int>>,
+    std::pair<undirected_graph<int, my_unweighted_edge<unsigned long>>,
+              my_unweighted_edge<unsigned long>>,
+    std::pair<undirected_graph<int, my_unweighted_edge<float>>,
+              my_unweighted_edge<float>>,
+    std::pair<undirected_graph<int, my_unweighted_edge<long double>>,
+              my_unweighted_edge<long double>>>;
+
+TYPED_TEST_CASE(UnweightedGraphTest, unweighted_graph_types);
+
+TYPED_TEST(UnweightedGraphTest, AddUnweightedEdge) {
+  // GIVEN
+  using graph_t = typename TestFixture::graph_t;
+  using edge_t = typename TestFixture::edge_t;
+  using weight_t = extract_weight<edge_t>::type;
+
+  graph_t graph{};
+
+  const auto vertex_id_1{graph.add_vertex(10)};
+  const auto vertex_id_2{graph.add_vertex(20)};
+
+  // WHEN
+  graph.add_edge(vertex_id_1, vertex_id_2, edge_t{static_cast<weight_t>(42)});
+
+  // THEN
+  ASSERT_TRUE(graph.has_edge(vertex_id_1, vertex_id_2));
+
+  // By default each edge has a unit weight
+  ASSERT_EQ(graph.get_edge(vertex_id_1, vertex_id_2)->val,
+            static_cast<weight_t>(42));
+}
+
 }  // namespace graaf


### PR DESCRIPTION
- If an edge is unweighted, the user can simply not derive from `weighted_edge`.
- It is now also possible to derive from `weighted_edge` but not implement `get_weight`. In that case a default implementation is provided which always returns a unit weight.