### PR TITLE
fix: stack overflow for const getters

### DIFF
--- a/include/graaflib/directed_graph.h
+++ b/include/graaflib/directed_graph.h
@@ -15,8 +15,8 @@ class directed_graph final
       vertex_id_t vertex_id_lhs,
       vertex_id_t vertex_id_rhs) const noexcept override;
 
-  [[nodiscard]] edge_t& do_get_edge(vertex_id_t vertex_id_lhs,
-                                    vertex_id_t vertex_id_rhs) override;
+  [[nodiscard]] const edge_t& do_get_edge(
+      vertex_id_t vertex_id_lhs, vertex_id_t vertex_id_rhs) const override;
 
   void do_add_edge(vertex_id_t vertex_id_lhs, vertex_id_t vertex_id_rhs,
                    edge_t edge) override;

--- a/include/graaflib/directed_graph.tpp
+++ b/include/graaflib/directed_graph.tpp
@@ -9,9 +9,9 @@ bool directed_graph<VERTEX_T, EDGE_T>::do_has_edge(
 }
 
 template <typename VERTEX_T, typename EDGE_T>
-typename directed_graph<VERTEX_T, EDGE_T>::edge_t&
+const typename directed_graph<VERTEX_T, EDGE_T>::edge_t&
 directed_graph<VERTEX_T, EDGE_T>::do_get_edge(vertex_id_t vertex_id_lhs,
-                                              vertex_id_t vertex_id_rhs) {
+                                              vertex_id_t vertex_id_rhs) const {
   return this->edges_.at({vertex_id_lhs, vertex_id_rhs});
 }
 

--- a/include/graaflib/graph.h
+++ b/include/graaflib/graph.h
@@ -215,8 +215,8 @@ class graph {
  private:
   [[nodiscard]] virtual bool do_has_edge(
       vertex_id_t vertex_id_lhs, vertex_id_t vertex_id_rhs) const noexcept = 0;
-  [[nodiscard]] virtual edge_t& do_get_edge(vertex_id_t vertex_id_lhs,
-                                            vertex_id_t vertex_id_rhs) = 0;
+  [[nodiscard]] virtual const edge_t& do_get_edge(
+      vertex_id_t vertex_id_lhs, vertex_id_t vertex_id_rhs) const = 0;
   virtual void do_add_edge(vertex_id_t vertex_id_lhs, vertex_id_t vertex_id_rhs,
                            edge_t edge) = 0;
   virtual void do_remove_edge(vertex_id_t vertex_id_lhs,

--- a/include/graaflib/graph.tpp
+++ b/include/graaflib/graph.tpp
@@ -40,6 +40,16 @@ bool graph<VERTEX_T, EDGE_T, GRAPH_SPEC_V>::has_edge(
 template <typename VERTEX_T, typename EDGE_T, graph_spec GRAPH_SPEC_V>
 VERTEX_T& graph<VERTEX_T, EDGE_T, GRAPH_SPEC_V>::get_vertex(
     vertex_id_t vertex_id) {
+  // Effective C++ item 3: we can safely call a const function from a non-const.
+  // one
+  return const_cast<VERTEX_T&>(
+      const_cast<const graph<VERTEX_T, EDGE_T, GRAPH_SPEC_V>*>(this)
+          ->get_vertex(vertex_id));
+}
+
+template <typename VERTEX_T, typename EDGE_T, graph_spec GRAPH_SPEC_V>
+const VERTEX_T& graph<VERTEX_T, EDGE_T, GRAPH_SPEC_V>::get_vertex(
+    vertex_id_t vertex_id) const {
   if (!has_vertex(vertex_id)) {
     // TODO(bluppes): replace with std::format once Clang supports it
     throw std::out_of_range{"Vertex with ID [" + std::to_string(vertex_id) +
@@ -50,15 +60,19 @@ VERTEX_T& graph<VERTEX_T, EDGE_T, GRAPH_SPEC_V>::get_vertex(
 }
 
 template <typename VERTEX_T, typename EDGE_T, graph_spec GRAPH_SPEC_V>
-const VERTEX_T& graph<VERTEX_T, EDGE_T, GRAPH_SPEC_V>::get_vertex(
-    vertex_id_t vertex_id) const {
-  return get_vertex(vertex_id);
-}
-
-template <typename VERTEX_T, typename EDGE_T, graph_spec GRAPH_SPEC_V>
 typename graph<VERTEX_T, EDGE_T, GRAPH_SPEC_V>::edge_t&
 graph<VERTEX_T, EDGE_T, GRAPH_SPEC_V>::get_edge(vertex_id_t vertex_id_lhs,
                                                 vertex_id_t vertex_id_rhs) {
+  // Effective C++ item 3: we can safely call a const function from a non-const.
+  return const_cast<graph<VERTEX_T, EDGE_T, GRAPH_SPEC_V>::edge_t&>(
+      const_cast<const graph<VERTEX_T, EDGE_T, GRAPH_SPEC_V>*>(this)->get_edge(
+          vertex_id_lhs, vertex_id_rhs));
+}
+
+template <typename VERTEX_T, typename EDGE_T, graph_spec GRAPH_SPEC_V>
+const typename graph<VERTEX_T, EDGE_T, GRAPH_SPEC_V>::edge_t&
+graph<VERTEX_T, EDGE_T, GRAPH_SPEC_V>::get_edge(
+    vertex_id_t vertex_id_lhs, vertex_id_t vertex_id_rhs) const {
   if (!has_edge(vertex_id_lhs, vertex_id_rhs)) {
     // TODO(bluppes): replace with std::format once Clang supports it
     throw std::out_of_range{"No edge found between vertices [" +
@@ -66,13 +80,6 @@ graph<VERTEX_T, EDGE_T, GRAPH_SPEC_V>::get_edge(vertex_id_t vertex_id_lhs,
                             std::to_string(vertex_id_rhs) + "]."};
   }
   return do_get_edge(vertex_id_lhs, vertex_id_rhs);
-}
-
-template <typename VERTEX_T, typename EDGE_T, graph_spec GRAPH_SPEC_V>
-const typename graph<VERTEX_T, EDGE_T, GRAPH_SPEC_V>::edge_t&
-graph<VERTEX_T, EDGE_T, GRAPH_SPEC_V>::get_edge(
-    vertex_id_t vertex_id_lhs, vertex_id_t vertex_id_rhs) const {
-  return get_edge(vertex_id_lhs, vertex_id_rhs);
 }
 
 template <typename VERTEX_T, typename EDGE_T, graph_spec GRAPH_SPEC_V>

--- a/include/graaflib/undirected_graph.h
+++ b/include/graaflib/undirected_graph.h
@@ -16,8 +16,8 @@ class undirected_graph final
       vertex_id_t vertex_id_lhs,
       vertex_id_t vertex_id_rhs) const noexcept override;
 
-  [[nodiscard]] edge_t& do_get_edge(vertex_id_t vertex_id_lhs,
-                                    vertex_id_t vertex_id_rhs) override;
+  [[nodiscard]] const edge_t& do_get_edge(
+      vertex_id_t vertex_id_lhs, vertex_id_t vertex_id_rhs) const override;
 
   void do_add_edge(vertex_id_t vertex_id_lhs, vertex_id_t vertex_id_rhs,
                    edge_t edge) override;

--- a/include/graaflib/undirected_graph.tpp
+++ b/include/graaflib/undirected_graph.tpp
@@ -20,9 +20,9 @@ bool undirected_graph<VERTEX_T, EDGE_T>::do_has_edge(
 }
 
 template <typename VERTEX_T, typename EDGE_T>
-typename undirected_graph<VERTEX_T, EDGE_T>::edge_t&
-undirected_graph<VERTEX_T, EDGE_T>::do_get_edge(vertex_id_t vertex_id_lhs,
-                                                vertex_id_t vertex_id_rhs) {
+const typename undirected_graph<VERTEX_T, EDGE_T>::edge_t&
+undirected_graph<VERTEX_T, EDGE_T>::do_get_edge(
+    vertex_id_t vertex_id_lhs, vertex_id_t vertex_id_rhs) const {
   return this->edges_.at(
       detail::make_sorted_pair(vertex_id_lhs, vertex_id_rhs));
 }

--- a/test/graaflib/graph_test.cpp
+++ b/test/graaflib/graph_test.cpp
@@ -203,4 +203,23 @@ TYPED_TEST(GraphTest, GetEdgeNonExistingEdge) {
       std::out_of_range);
 }
 
+TYPED_TEST(GraphTest, ConstGetter) {
+  using vertex_id_t = std::size_t;
+  using graph_t = typename TestFixture::graph_t;
+  graph_t graph{};
+  const auto vertex_id_1 = graph.add_vertex(1);
+  const auto vertex_id_2 = graph.add_vertex(2);
+  graph.add_edge(vertex_id_1, vertex_id_2, 100);
+
+  const auto test_getters_on_const_graph{
+      [vertex_id_1, vertex_id_2](const graph_t &const_graph) {
+        EXPECT_EQ(const_graph.get_vertex(vertex_id_1), 1);
+        EXPECT_EQ(const_graph.get_vertex(vertex_id_2), 2);
+        EXPECT_EQ(const_graph.get_edge(vertex_id_1, vertex_id_2)->get_weight(),
+                  100);
+      }};
+
+  ASSERT_NO_THROW(test_getters_on_const_graph(graph));
+}
+
 }  // namespace graaf


### PR DESCRIPTION
Previously there was a bug where calling a getter (`get_edge` or `get_vertex`) on a `const` graph invoked an infinite recursion, resulting in a stack overflow. This is solved by calling const getters from within the non-const getters as per Effective C++ item 3. 

Since the member function calling it is non-const, the object itself is non-const, and casting away the const is allowed.