### PR TITLE
perf: perfect forwarding

### DIFF
--- a/examples/dot_serialization/main.cpp
+++ b/examples/dot_serialization/main.cpp
@@ -31,18 +31,18 @@ struct my_edge {
 auto create_graph() {
   graaf::directed_graph<my_vertex, my_edge> graph{};
 
-  const auto vertex_1{graph.add_vertex({10, "some data"})};
-  const auto vertex_2{graph.add_vertex({20, "some more data"})};
-  const auto vertex_3{graph.add_vertex({30, "abc"})};
-  const auto vertex_4{graph.add_vertex({40, "123"})};
-  const auto vertex_5{graph.add_vertex({50, "xyz"})};
+  const auto vertex_1{graph.add_vertex(my_vertex{10, "some data"})};
+  const auto vertex_2{graph.add_vertex(my_vertex{20, "some more data"})};
+  const auto vertex_3{graph.add_vertex(my_vertex{30, "abc"})};
+  const auto vertex_4{graph.add_vertex(my_vertex{40, "123"})};
+  const auto vertex_5{graph.add_vertex(my_vertex{50, "xyz"})};
 
-  graph.add_edge(vertex_1, vertex_2, {edge_priority::HIGH, 3.3});
-  graph.add_edge(vertex_2, vertex_1, {edge_priority::HIGH, 5.0});
-  graph.add_edge(vertex_1, vertex_3, {edge_priority::HIGH, 1.0});
-  graph.add_edge(vertex_3, vertex_4, {edge_priority::LOW, 2.0});
-  graph.add_edge(vertex_3, vertex_5, {edge_priority::HIGH, 3.0});
-  graph.add_edge(vertex_2, vertex_5, {edge_priority::LOW, 42.0});
+  graph.add_edge(vertex_1, vertex_2, my_edge{edge_priority::HIGH, 3.3});
+  graph.add_edge(vertex_2, vertex_1, my_edge{edge_priority::HIGH, 5.0});
+  graph.add_edge(vertex_1, vertex_3, my_edge{edge_priority::HIGH, 1.0});
+  graph.add_edge(vertex_3, vertex_4, my_edge{edge_priority::LOW, 2.0});
+  graph.add_edge(vertex_3, vertex_5, my_edge{edge_priority::HIGH, 3.0});
+  graph.add_edge(vertex_2, vertex_5, my_edge{edge_priority::LOW, 42.0});
 
   return graph;
 }

--- a/include/graaflib/graph.h
+++ b/include/graaflib/graph.h
@@ -180,7 +180,7 @@ class graph {
    * @param  vertex The vertex to be added
    * @return vertices_id_t - The ID of the new vertex
    */
-  vertex_id_t add_vertex(VERTEX_T vertex);
+  vertex_id_t add_vertex(auto&& vertex);
 
   /**
    * Remove a vertex from the graph and update all its neighbors
@@ -196,7 +196,7 @@ class graph {
    * @throws out_of_range - If either of the vertex does not exist in graph
    */
   void add_edge(vertex_id_t vertex_id_lhs, vertex_id_t vertex_id_rhs,
-                EDGE_T edge);
+                auto&& edge);
 
   /**
    * Remove the edge between two vertices

--- a/include/graaflib/graph.tpp
+++ b/include/graaflib/graph.tpp
@@ -93,10 +93,10 @@ graph<VERTEX_T, EDGE_T, GRAPH_SPEC_V>::get_neighbors(
 }
 
 template <typename VERTEX_T, typename EDGE_T, graph_spec GRAPH_SPEC_V>
-vertex_id_t graph<VERTEX_T, EDGE_T, GRAPH_SPEC_V>::add_vertex(VERTEX_T vertex) {
+vertex_id_t graph<VERTEX_T, EDGE_T, GRAPH_SPEC_V>::add_vertex(auto&& vertex) {
   // TODO: check overflow
   const auto vertex_id{vertex_id_supplier_++};
-  vertices_.emplace(vertex_id, std::move(vertex));
+  vertices_.emplace(vertex_id, std::forward<VERTEX_T>(vertex));
   return vertex_id;
 }
 
@@ -121,7 +121,7 @@ void graph<VERTEX_T, EDGE_T, GRAPH_SPEC_V>::remove_vertex(
 template <typename VERTEX_T, typename EDGE_T, graph_spec GRAPH_SPEC_V>
 void graph<VERTEX_T, EDGE_T, GRAPH_SPEC_V>::add_edge(vertex_id_t vertex_id_lhs,
                                                      vertex_id_t vertex_id_rhs,
-                                                     EDGE_T edge) {
+                                                     auto&& edge) {
   if (!has_vertex(vertex_id_lhs) || !has_vertex(vertex_id_rhs)) {
     // TODO(bluppes): replace with std::format once Clang supports it
     throw std::out_of_range{
@@ -129,7 +129,8 @@ void graph<VERTEX_T, EDGE_T, GRAPH_SPEC_V>::add_edge(vertex_id_t vertex_id_lhs,
         std::to_string(vertex_id_rhs) + "] not found in graph."};
   }
   do_add_edge(vertex_id_lhs, vertex_id_rhs,
-              std::make_shared<typename edge_t::element_type>(edge));
+              std::make_shared<typename edge_t::element_type>(
+                  std::forward<EDGE_T>(edge)));
 }
 
 template <typename VERTEX_T, typename EDGE_T, graph_spec GRAPH_SPEC_V>

--- a/perf/graaflib/add_edge_benchmark.cpp
+++ b/perf/graaflib/add_edge_benchmark.cpp
@@ -49,7 +49,7 @@ static void bm_add_user_defined_edge(benchmark::State& state) {
   const auto vertices{create_vertices(graph, number_of_vertices)};
 
   for (auto _ : state) {
-    for (size_t i{0}; i < number_of_vertices; ++i) {
+    for (size_t i{0}; i < number_of_edges; ++i) {
       graph.add_edge(vertices[i], vertices[i + 1], edge{});
     }
   }

--- a/perf/graaflib/add_edge_benchmark.cpp
+++ b/perf/graaflib/add_edge_benchmark.cpp
@@ -1,7 +1,7 @@
 #include <benchmark/benchmark.h>
 #include <graaflib/directed_graph.h>
 
-#include <array>
+#include <vector>
 
 namespace {
 
@@ -35,7 +35,8 @@ static void bm_add_primitive_numeric_edge(benchmark::State& state) {
 }
 
 struct edge {
-  std::array<double, 100> data{};
+  // Something which benefits from move construction
+  std::vector<double> data{100};
 };
 
 static void bm_add_user_defined_edge(benchmark::State& state) {

--- a/perf/graaflib/add_vertex_benchmark.cpp
+++ b/perf/graaflib/add_vertex_benchmark.cpp
@@ -1,7 +1,7 @@
 #include <benchmark/benchmark.h>
 #include <graaflib/directed_graph.h>
 
-#include <array>
+#include <vector>
 
 namespace {
 
@@ -17,7 +17,8 @@ static void bm_add_primitive_numeric_vertex(benchmark::State& state) {
 }
 
 struct vertex {
-  std::array<double, 100> data{};
+  // Something which benefits from move construction
+  std::vector<double> data{100};
 };
 
 static void bm_add_user_defined_vertex(benchmark::State& state) {

--- a/test/graaflib/io/dot_test.cpp
+++ b/test/graaflib/io/dot_test.cpp
@@ -202,9 +202,9 @@ TEST(DotTest, UserProvidedVertexAndEdgeClass) {
   const std::filesystem::path path{"./test.dot"};
   directed_graph<vertex_t, edge_t> graph{};
 
-  const auto vertex_1{graph.add_vertex({10, "vertex 1"})};
-  const auto vertex_2{graph.add_vertex({20, "vertex 2"})};
-  graph.add_edge(vertex_1, vertex_2, {100, "edge 1"});
+  const auto vertex_1{graph.add_vertex(vertex_t{10, "vertex 1"})};
+  const auto vertex_2{graph.add_vertex(vertex_t{20, "vertex 2"})};
+  graph.add_edge(vertex_1, vertex_2, edge_t{100, "edge 1"});
 
   const auto vertex_writer{
       [](vertex_id_t /*vertex_id*/, const vertex_t& vertex) {


### PR DESCRIPTION
I did not measure any significant performance improvement when building in release mode. I expect the compiler is able to optimize the redundant move construction. Nevertheless, I think perfect forwarding is still a nice to have.

## add vertex benchmarks
![vertex](https://github.com/bobluppes/graaf/assets/18380160/2a454ead-a049-4b91-9d16-b893c8cac127)

## add edge benchmarks
![edge](https://github.com/bobluppes/graaf/assets/18380160/7110a7aa-11dd-45cf-8ef6-249a9061bc82)
