### PR TITLE
tooling: Benchmark visualization script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 build/
 
+venv
 
 # IDE
 .vscode/

--- a/tools/benchmark_visualization.py
+++ b/tools/benchmark_visualization.py
@@ -1,0 +1,46 @@
+import pandas as pd
+import matplotlib.pyplot as plt
+from pathlib import Path
+import os
+
+benchmark_dir = Path("../build")
+benchmark_filter = "bm_"
+google_benchmark_skiprows = 10
+
+plt.figure()
+
+for benchmark_results in benchmark_dir.glob("*.csv"):
+    filename = os.path.basename(benchmark_results)
+    benchmarks_df = pd.read_csv(benchmark_results, skiprows=google_benchmark_skiprows)
+
+    # The benchmark name and variable are recorded as 'bm_name/variable'
+    benchmarks_df[["bm_name", "variable"]] = benchmarks_df["name"].str.split(
+        pat="/", n=1, expand=True
+    )
+    benchmarks_df["variable"] = benchmarks_df["variable"].astype(int)
+
+    # Google benchmark records the time in ns
+    benchmarks_df["time (s)"] = benchmarks_df["real_time"].apply(lambda x: x * 1e-9)
+
+    # Filter
+    benchmarks_df = benchmarks_df[
+        benchmarks_df["bm_name"].apply(lambda x: x.find(benchmark_filter) != -1)
+    ]
+
+    for benchmark_df in [x for _, x in benchmarks_df.groupby("bm_name")]:
+        benchmark_label = "{} - {}".format(
+            os.path.splitext(filename)[0], benchmark_df["bm_name"].iloc[0]
+        )
+
+        plt.plot(
+            benchmark_df["variable"],
+            benchmark_df["time (s)"],
+            label=benchmark_label,
+            marker=".",
+        )
+
+plt.xlabel("number of additions")
+plt.ylabel("runtime (s)")
+plt.xscale("log")
+plt.legend()
+plt.show()

--- a/tools/benchmark_visualization.py
+++ b/tools/benchmark_visualization.py
@@ -15,7 +15,7 @@ build/perf/Graaf_perf --benchmark_out=benchmark_results.csv --benchmark_out_form
 
 def read_benchmark_files_into_df(dir=Path("../build"), skiprows=10):
     df = pd.DataFrame()
-    for file in dir.glob("*.csv"):
+    for file in dir.glob("**/*.csv"):
         df_new = pd.read_csv(file, skiprows=skiprows)
         df_new["filename"] = Path(file).stem
         df = pd.concat([df, df_new], ignore_index=True)

--- a/tools/benchmark_visualization.py
+++ b/tools/benchmark_visualization.py
@@ -3,8 +3,19 @@ import matplotlib.pyplot as plt
 from pathlib import Path
 import os
 
-benchmark_dir = Path("../build")
-benchmark_filter = "bm_"
+"""
+This script can be used to visualize benchmark results. The script assumes multiple benchmark 
+results in csv files under the build directory. These results can be generated with the 
+Graaf_perf executable:
+
+build/perf/Graaf_perf --benchmark_out=benchmark_results.csv --benchmark_out_format=csv
+"""
+
+# Input variables
+benchmark_dir = Path("../build")  # The directory containing the csv files
+benchmark_filter = "bm_"  # Option to filter on specific benchmark names
+
+# Constants
 google_benchmark_skiprows = 10
 
 plt.figure()

--- a/tools/benchmark_visualization.py
+++ b/tools/benchmark_visualization.py
@@ -1,7 +1,8 @@
-import pandas as pd
-import matplotlib.pyplot as plt
-from pathlib import Path
 import os
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import pandas as pd
 
 """
 This script can be used to visualize benchmark results. The script assumes multiple benchmark 
@@ -11,47 +12,50 @@ Graaf_perf executable:
 build/perf/Graaf_perf --benchmark_out=benchmark_results.csv --benchmark_out_format=csv
 """
 
-# Input variables
-benchmark_dir = Path("../build")  # The directory containing the csv files
-benchmark_filter = "bm_"  # Option to filter on specific benchmark names
 
-# Constants
-google_benchmark_skiprows = 10
+def plot_benchmarks_from_csv(
+    benchmark_dir=Path("../build"), benchmark_filter="bm_", google_benchmark_skiprows=10
+):
+    plt.figure()
 
-plt.figure()
-
-for benchmark_results in benchmark_dir.glob("*.csv"):
-    filename = os.path.basename(benchmark_results)
-    benchmarks_df = pd.read_csv(benchmark_results, skiprows=google_benchmark_skiprows)
-
-    # The benchmark name and variable are recorded as 'bm_name/variable'
-    benchmarks_df[["bm_name", "variable"]] = benchmarks_df["name"].str.split(
-        pat="/", n=1, expand=True
-    )
-    benchmarks_df["variable"] = benchmarks_df["variable"].astype(int)
-
-    # Google benchmark records the time in ns
-    benchmarks_df["time (s)"] = benchmarks_df["real_time"].apply(lambda x: x * 1e-9)
-
-    # Filter
-    benchmarks_df = benchmarks_df[
-        benchmarks_df["bm_name"].apply(lambda x: x.find(benchmark_filter) != -1)
-    ]
-
-    for benchmark_df in [x for _, x in benchmarks_df.groupby("bm_name")]:
-        benchmark_label = "{} - {}".format(
-            os.path.splitext(filename)[0], benchmark_df["bm_name"].iloc[0]
+    for benchmark_results in benchmark_dir.glob("*.csv"):
+        filename = os.path.basename(benchmark_results)
+        benchmarks_df = pd.read_csv(
+            benchmark_results, skiprows=google_benchmark_skiprows
         )
 
-        plt.plot(
-            benchmark_df["variable"],
-            benchmark_df["time (s)"],
-            label=benchmark_label,
-            marker=".",
+        # The benchmark name and variable are recorded as 'bm_name/variable'
+        benchmarks_df[["bm_name", "variable"]] = benchmarks_df["name"].str.split(
+            pat="/", n=1, expand=True
         )
+        benchmarks_df["variable"] = benchmarks_df["variable"].astype(int)
 
-plt.xlabel("number of additions")
-plt.ylabel("runtime (s)")
-plt.xscale("log")
-plt.legend()
-plt.show()
+        # Google benchmark records the time in ns
+        benchmarks_df["time (s)"] = benchmarks_df["real_time"].apply(lambda x: x * 1e-9)
+
+        # Filter
+        benchmarks_df = benchmarks_df[
+            benchmarks_df["bm_name"].apply(lambda x: x.find(benchmark_filter) != -1)
+        ]
+
+        for benchmark_df in [x for _, x in benchmarks_df.groupby("bm_name")]:
+            benchmark_label = "{} - {}".format(
+                os.path.splitext(filename)[0], benchmark_df["bm_name"].iloc[0]
+            )
+
+            plt.plot(
+                benchmark_df["variable"],
+                benchmark_df["time (s)"],
+                label=benchmark_label,
+                marker=".",
+            )
+
+    plt.xlabel("number of additions")
+    plt.ylabel("runtime (s)")
+    plt.xscale("log")
+    plt.legend()
+    plt.show()
+
+
+if __name__ == "__main__":
+    plot_benchmarks_from_csv()

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -1,0 +1,14 @@
+contourpy==1.1.0
+cycler==0.11.0
+fonttools==4.41.1
+kiwisolver==1.4.4
+matplotlib==3.7.2
+numpy==1.25.1
+packaging==23.1
+pandas==2.0.3
+Pillow==10.0.0
+pyparsing==3.0.9
+python-dateutil==2.8.2
+pytz==2023.3
+six==1.16.0
+tzdata==2023.3

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -10,5 +10,6 @@ Pillow==10.0.0
 pyparsing==3.0.9
 python-dateutil==2.8.2
 pytz==2023.3
+seaborn==0.12.2
 six==1.16.0
 tzdata==2023.3


### PR DESCRIPTION
This PR adds a python script under `tools/`, which can be used to visualize google benchmark data. An example plot can be found below.

Not very familiar with python, so any improvement suggestions are more than welcome.

![vertex](https://github.com/bobluppes/graaf/assets/18380160/e617fb70-cc80-451c-9750-6b264d4e52cd)