### PR TITLE
breaking-change: Expose algorith names to interface

### DIFF
--- a/docs/docs/examples/example-basics/shortest-path.md
+++ b/docs/docs/examples/example-basics/shortest-path.md
@@ -3,7 +3,9 @@ sidebar_position: 2
 ---
 
 # Shortest Path Example
-The shortest path algorithm implemented in `graaf::algorithm::get_shortest_path` can be used to compute the shortest path between any two vertices in a graph.
+
+The shortest path algorithm implemented in `graaf::algorithm::get_shortest_path` can be used to compute the shortest
+path between any two vertices in a graph.
 
 Consider the following graph:
 
@@ -16,7 +18,7 @@ Consider the following graph:
 In order to compute the shortest path between *vertex 0* and *vertex 2*, we call:
 
 ```c++
-const auto maybe_shortest_path{get_shortest_path<edge_strategy::UNWEIGHTED>(graph, start, target)};
+const auto maybe_shortest_path{bfs_shortest_path(graph, start, target)};
 
 // Assert that we found a path at all
 assert(maybe_shortest_path.has_value());
@@ -24,7 +26,9 @@ auto shortest_path{maybe_shortest_path.value()};
 ```
 
 ## Visualizing the shortest path
-If we want to visualize the shortest path on the graph, we can create our own vertex and edge writers. These writers then determine the vertex and edge attributes based on whether the vertex or edge is contained in the shortest path.
+
+If we want to visualize the shortest path on the graph, we can create our own vertex and edge writers. These writers
+then determine the vertex and edge attributes based on whether the vertex or edge is contained in the shortest path.
 
 First, we create a datastructure of all edges on the shortest path such that we can query it in the edge writer:
 
@@ -62,6 +66,7 @@ const auto edge_writer{
   return "label=\"\", color=gray, style=dashed";
 }};
 ```
+
 This yields us the following visualization:
 
 <pre>

--- a/examples/shortest_path/main.cpp
+++ b/examples/shortest_path/main.cpp
@@ -39,8 +39,8 @@ graph_with_start_and_target create_graph_with_start_and_target() {
 int main() {
   const auto [graph, start, target]{create_graph_with_start_and_target()};
 
-  const auto maybe_shortest_path{graaf::algorithm::get_shortest_path<
-      graaf::algorithm::edge_strategy::UNWEIGHTED>(graph, start, target)};
+  const auto maybe_shortest_path{
+      graaf::algorithm::bfs_shortest_path(graph, start, target)};
   assert(maybe_shortest_path.has_value());
   auto shortest_path{maybe_shortest_path.value()};
 

--- a/include/graaflib/algorithm/cycle_detection.h
+++ b/include/graaflib/algorithm/cycle_detection.h
@@ -5,12 +5,22 @@
 namespace graaf::algorithm {
 
 /*
- * @brief Traverses the graph and checks for cycles.
+ * @brief Traverses a directed graph and checks for cycles.
  *
- * @param graph The graph to traverse.
+ * @param graph The directed graph to traverse.
  */
-template <typename V, typename E, graph_type T>
-[[nodiscard]] bool has_cycle(const graph<V, E, T> &graph);
+template <typename V, typename E>
+[[nodiscard]] bool dfs_cycle_detection(
+    const graph<V, E, graph_type::DIRECTED> &graph);
+
+/*
+ * @brief Traverses an undirected graph and checks for cycles.
+ *
+ * @param graph The undirected graph to traverse.
+ */
+template <typename V, typename E>
+[[nodiscard]] bool dfs_cycle_detection(
+    const graph<V, E, graph_type::UNDIRECTED> &graph);
 
 }  // namespace graaf::algorithm
 

--- a/include/graaflib/algorithm/cycle_detection.tpp
+++ b/include/graaflib/algorithm/cycle_detection.tpp
@@ -11,9 +11,9 @@ namespace detail {
 
 enum class vertex_color { UNVISITED, VISITED, NO_CYCLE };
 
-template <typename V, typename E, graph_type T>
+template <typename V, typename E>
 bool do_dfs_directed(
-    const graph<V, E, T>& graph,
+    const graph<V, E, graph_type::DIRECTED>& graph,
     std::unordered_map<vertex_id_t, vertex_color>& colored_vertices,
     vertex_id_t current) {
   colored_vertices[current] = vertex_color::VISITED;
@@ -31,9 +31,9 @@ bool do_dfs_directed(
   return false;
 }
 
-template <typename V, typename E, graph_type T>
+template <typename V, typename E>
 bool do_dfs_undirected(
-    const graph<V, E, T>& graph,
+    const graph<V, E, graph_type::UNDIRECTED>& graph,
     std::unordered_map<vertex_id_t, bool>& visited_vertices,
     std::unordered_map<vertex_id_t, vertex_id_t>& parent_vertices,
     vertex_id_t parent_vertex, vertex_id_t current) {
@@ -58,39 +58,37 @@ bool do_dfs_undirected(
 
 }  // namespace detail
 
-template <typename V, typename E, graph_type T>
-bool has_cycle(const graph<V, E, T>& graph) {
-  if (graph.is_directed()) {
-    std::unordered_map<vertex_id_t, detail::vertex_color> colored_vertices{};
+template <typename V, typename E>
+bool dfs_cycle_detection(const graph<V, E, graph_type::DIRECTED>& graph) {
+  std::unordered_map<vertex_id_t, detail::vertex_color> colored_vertices{};
 
-    for (const auto& vertex : graph.get_vertices()) {
-      using enum detail::vertex_color;
-      if (colored_vertices[vertex.first] == UNVISITED &&
-          detail::do_dfs_directed(graph, colored_vertices, vertex.first)) {
-        return true;
-      }
-    }
-
-    return false;
-  }
-
-  if (graph.is_undirected()) {
-    // Number of vertices cannot be zero (in case if graph is empty)
-    if (graph.edge_count() >= graph.vertex_count() &&
-        graph.vertex_count() > 0) {
+  for (const auto& vertex : graph.get_vertices()) {
+    using enum detail::vertex_color;
+    if (colored_vertices[vertex.first] == UNVISITED &&
+        detail::do_dfs_directed(graph, colored_vertices, vertex.first)) {
       return true;
     }
+  }
 
-    std::unordered_map<vertex_id_t, bool> visited_vertices{};
-    std::unordered_map<vertex_id_t, vertex_id_t> parent_vertices{};
+  return false;
+}
 
-    for (const auto& vertex : graph.get_vertices()) {
-      if (!visited_vertices.contains(vertex.first) &&
-          detail::do_dfs_undirected(graph, visited_vertices, parent_vertices,
-                                    vertex.first,
-                                    parent_vertices[vertex.first])) {
-        return true;
-      }
+template <typename V, typename E>
+bool dfs_cycle_detection(const graph<V, E, graph_type::UNDIRECTED>& graph) {
+  // Number of vertices cannot be zero (in case if graph is empty)
+  if (graph.edge_count() >= graph.vertex_count() && graph.vertex_count() > 0) {
+    return true;
+  }
+
+  std::unordered_map<vertex_id_t, bool> visited_vertices{};
+  std::unordered_map<vertex_id_t, vertex_id_t> parent_vertices{};
+
+  for (const auto& vertex : graph.get_vertices()) {
+    if (!visited_vertices.contains(vertex.first) &&
+        detail::do_dfs_undirected(graph, visited_vertices, parent_vertices,
+                                  vertex.first,
+                                  parent_vertices[vertex.first])) {
+      return true;
     }
   }
 

--- a/include/graaflib/algorithm/graph_traversal.h
+++ b/include/graaflib/algorithm/graph_traversal.h
@@ -7,24 +7,34 @@
 
 namespace graaf::algorithm {
 
-enum class search_strategy { DFS, BFS };
-
 /**
  * @brief Traverses the graph, starting at start_vertex, and visits all
- * reachable vertices.
+ * reachable vertices in a BFS manner.
  *
- * @tparam ALGORITHM Tag to specify the search algorithm, can be either DFS of
- * BFS.
  * @param graph The graph to traverse.
  * @param start_vertex Vertex id where the traversal should be started.
  * @param callback A callback which is called for each traversed vertex. Should
  * be invocable with a vertex_id_t.
  */
-template <search_strategy ALGORITHM, typename V, typename E, graph_type T,
-          typename CALLBACK_T>
+template <typename V, typename E, graph_type T, typename CALLBACK_T>
   requires std::invocable<const CALLBACK_T &, vertex_id_t>
-void traverse(const graph<V, E, T> &graph, vertex_id_t start_vertex,
-              const CALLBACK_T &callback);
+void breadth_first_traverse(const graph<V, E, T> &graph,
+                            vertex_id_t start_vertex,
+                            const CALLBACK_T &callback);
+
+/**
+ * @brief Traverses the graph, starting at start_vertex, and visits all
+ * reachable vertices in a DFS manner.
+ *
+ * @param graph The graph to traverse.
+ * @param start_vertex Vertex id where the traversal should be started.
+ * @param callback A callback which is called for each traversed vertex. Should
+ * be invocable with a vertex_id_t.
+ */
+template <typename V, typename E, graph_type T, typename CALLBACK_T>
+  requires std::invocable<const CALLBACK_T &, vertex_id_t>
+void depth_first_traverse(const graph<V, E, T> &graph, vertex_id_t start_vertex,
+                          const CALLBACK_T &callback);
 
 }  // namespace graaf::algorithm
 

--- a/include/graaflib/algorithm/graph_traversal.tpp
+++ b/include/graaflib/algorithm/graph_traversal.tpp
@@ -9,20 +9,6 @@ namespace graaf::algorithm {
 namespace detail {
 
 template <typename V, typename E, graph_type T, typename CALLBACK_T>
-void do_dfs(const graph<V, E, T>& graph,
-            std::unordered_set<vertex_id_t>& seen_vertices, vertex_id_t current,
-            const CALLBACK_T& callback) {
-  callback(current);
-  seen_vertices.insert(current);
-
-  for (auto neighbor_vertex : graph.get_neighbors(current)) {
-    if (!seen_vertices.contains(neighbor_vertex)) {
-      do_dfs(graph, seen_vertices, neighbor_vertex, callback);
-    }
-  }
-}
-
-template <typename V, typename E, graph_type T, typename CALLBACK_T>
 void do_bfs(const graph<V, E, T>& graph,
             std::unordered_set<vertex_id_t>& seen_vertices,
             vertex_id_t start_vertex, const CALLBACK_T& callback) {
@@ -49,26 +35,37 @@ void do_bfs(const graph<V, E, T>& graph,
   }
 }
 
+template <typename V, typename E, graph_type T, typename CALLBACK_T>
+void do_dfs(const graph<V, E, T>& graph,
+            std::unordered_set<vertex_id_t>& seen_vertices, vertex_id_t current,
+            const CALLBACK_T& callback) {
+  callback(current);
+  seen_vertices.insert(current);
+
+  for (auto neighbor_vertex : graph.get_neighbors(current)) {
+    if (!seen_vertices.contains(neighbor_vertex)) {
+      do_dfs(graph, seen_vertices, neighbor_vertex, callback);
+    }
+  }
+}
+
 }  // namespace detail
 
-template <search_strategy ALGORITHM, typename V, typename E, graph_type T,
-          typename CALLBACK_T>
+template <typename V, typename E, graph_type T, typename CALLBACK_T>
   requires std::invocable<const CALLBACK_T&, vertex_id_t>
-void traverse(const graph<V, E, T>& graph, vertex_id_t start_vertex,
-              const CALLBACK_T& callback) {
+void breadth_first_traverse(const graph<V, E, T>& graph,
+                            vertex_id_t start_vertex,
+                            const CALLBACK_T& callback) {
   std::unordered_set<vertex_id_t> seen_vertices{};
+  return detail::do_bfs(graph, seen_vertices, start_vertex, callback);
+}
 
-  using enum search_strategy;
-  if constexpr (ALGORITHM == DFS) {
-    return detail::do_dfs(graph, seen_vertices, start_vertex, callback);
-  }
-
-  if constexpr (ALGORITHM == BFS) {
-    return detail::do_bfs(graph, seen_vertices, start_vertex, callback);
-  }
-
-  // We should never reach this
-  std::abort();
+template <typename V, typename E, graph_type T, typename CALLBACK_T>
+  requires std::invocable<const CALLBACK_T&, vertex_id_t>
+void depth_first_traverse(const graph<V, E, T>& graph, vertex_id_t start_vertex,
+                          const CALLBACK_T& callback) {
+  std::unordered_set<vertex_id_t> seen_vertices{};
+  return detail::do_dfs(graph, seen_vertices, start_vertex, callback);
 }
 
 }  // namespace graaf::algorithm

--- a/include/graaflib/algorithm/shortest_path.h
+++ b/include/graaflib/algorithm/shortest_path.h
@@ -9,9 +9,6 @@
 
 namespace graaf::algorithm {
 
-// TODO(bluppes): I would expose the names of the underlying algorithms here.
-enum class edge_strategy { WEIGHTED, UNWEIGHTED };
-
 template <typename WEIGHT_T>
 struct GraphPath {
   std::list<vertex_id_t> vertices;
@@ -24,17 +21,31 @@ struct GraphPath {
 
 /**
  * @brief calculates the shortest path between on start_vertex and one
- * end_vertex.
+ * end_vertex using BFS. This does not consider edge weights.
  *
- * @tparam EDGE_STRATEGY Tag to specify how to handle edges, can be either
- * WEIGHTED or UNWEIGHTED.
  * @param graph The graph to extract shortest path from.
  * @param start_vertex Vertex id where the shortest path should start.
  * @param end_vertex Vertex id where the shortest path should end.
  */
-template <edge_strategy EDGE_STRATEGY, typename V, typename E, graph_type T,
+template <typename V, typename E, graph_type T,
           typename WEIGHT_T = decltype(get_weight(std::declval<E>()))>
-std::optional<GraphPath<WEIGHT_T>> get_shortest_path(
+std::optional<GraphPath<WEIGHT_T>> bfs_shortest_path(
+    const graph<V, E, T>& graph, vertex_id_t start_vertex,
+    vertex_id_t end_vertex);
+
+/**
+ * @brief calculates the shortest path between on start_vertex and one
+ * end_vertex using Dijkstra's algorithm. Works on both weighted as well as
+ * unweighted graphs. For unweighted graphs, a unit weight is used for each
+ * edge.
+ *
+ * @param graph The graph to extract shortest path from.
+ * @param start_vertex Vertex id where the shortest path should start.
+ * @param end_vertex Vertex id where the shortest path should end.
+ */
+template <typename V, typename E, graph_type T,
+          typename WEIGHT_T = decltype(get_weight(std::declval<E>()))>
+std::optional<GraphPath<WEIGHT_T>> dijkstra_shortest_path(
     const graph<V, E, T>& graph, vertex_id_t start_vertex,
     vertex_id_t end_vertex);
 

--- a/include/graaflib/algorithm/shortest_path.h
+++ b/include/graaflib/algorithm/shortest_path.h
@@ -10,11 +10,11 @@
 namespace graaf::algorithm {
 
 template <typename WEIGHT_T>
-struct GraphPath {
+struct graph_path {
   std::list<vertex_id_t> vertices;
   WEIGHT_T total_weight;
 
-  bool operator==(const GraphPath& other) const {
+  bool operator==(const graph_path& other) const {
     return vertices == other.vertices && total_weight == other.total_weight;
   }
 };
@@ -29,7 +29,7 @@ struct GraphPath {
  */
 template <typename V, typename E, graph_type T,
           typename WEIGHT_T = decltype(get_weight(std::declval<E>()))>
-std::optional<GraphPath<WEIGHT_T>> bfs_shortest_path(
+std::optional<graph_path<WEIGHT_T>> bfs_shortest_path(
     const graph<V, E, T>& graph, vertex_id_t start_vertex,
     vertex_id_t end_vertex);
 
@@ -45,7 +45,7 @@ std::optional<GraphPath<WEIGHT_T>> bfs_shortest_path(
  */
 template <typename V, typename E, graph_type T,
           typename WEIGHT_T = decltype(get_weight(std::declval<E>()))>
-std::optional<GraphPath<WEIGHT_T>> dijkstra_shortest_path(
+std::optional<graph_path<WEIGHT_T>> dijkstra_shortest_path(
     const graph<V, E, T>& graph, vertex_id_t start_vertex,
     vertex_id_t end_vertex);
 

--- a/include/graaflib/algorithm/shortest_path.tpp
+++ b/include/graaflib/algorithm/shortest_path.tpp
@@ -42,11 +42,13 @@ std::optional<GraphPath<WEIGHT_T>> reconstruct_path(
   return path;
 }
 
+}  // namespace detail
+
 template <typename V, typename E, graph_type T, typename WEIGHT_T>
-std::optional<GraphPath<WEIGHT_T>> get_unweighted_shortest_path(
+std::optional<GraphPath<WEIGHT_T>> bfs_shortest_path(
     const graph<V, E, T>& graph, vertex_id_t start_vertex,
     vertex_id_t end_vertex) {
-  std::unordered_map<vertex_id_t, PathVertex<WEIGHT_T>> vertex_info;
+  std::unordered_map<vertex_id_t, detail::PathVertex<WEIGHT_T>> vertex_info;
   std::queue<vertex_id_t> to_explore{};
 
   vertex_info[start_vertex] = {start_vertex, 1, start_vertex};
@@ -73,12 +75,12 @@ std::optional<GraphPath<WEIGHT_T>> get_unweighted_shortest_path(
 }
 
 template <typename V, typename E, graph_type T, typename WEIGHT_T>
-std::optional<GraphPath<WEIGHT_T>> get_weighted_shortest_path(
+std::optional<GraphPath<WEIGHT_T>> dijkstra_shortest_path(
     const graph<V, E, T>& graph, vertex_id_t start_vertex,
     vertex_id_t end_vertex) {
-  std::unordered_map<vertex_id_t, PathVertex<WEIGHT_T>> vertex_info;
+  std::unordered_map<vertex_id_t, detail::PathVertex<WEIGHT_T>> vertex_info;
 
-  using weighted_path_item = PathVertex<WEIGHT_T>;
+  using weighted_path_item = detail::PathVertex<WEIGHT_T>;
   std::priority_queue<weighted_path_item, std::vector<weighted_path_item>,
                       std::greater<>>
       to_explore{};
@@ -107,25 +109,6 @@ std::optional<GraphPath<WEIGHT_T>> get_weighted_shortest_path(
   }
 
   return reconstruct_path(start_vertex, end_vertex, vertex_info);
-}
-
-}  // namespace detail
-
-template <edge_strategy EDGE_STRATEGY, typename V, typename E, graph_type T,
-          typename WEIGHT_T>
-std::optional<GraphPath<WEIGHT_T>> get_shortest_path(
-    const graph<V, E, T>& graph, vertex_id_t start_vertex,
-    vertex_id_t end_vertex) {
-  using enum edge_strategy;
-  if constexpr (EDGE_STRATEGY == UNWEIGHTED) {
-    return detail::get_unweighted_shortest_path<V, E, T, WEIGHT_T>(
-        graph, start_vertex, end_vertex);
-  }
-
-  if constexpr (EDGE_STRATEGY == WEIGHTED) {
-    return detail::get_weighted_shortest_path<V, E, T, WEIGHT_T>(
-        graph, start_vertex, end_vertex);
-  }
 }
 
 }  // namespace graaf::algorithm

--- a/include/graaflib/algorithm/shortest_path.tpp
+++ b/include/graaflib/algorithm/shortest_path.tpp
@@ -11,25 +11,25 @@ namespace graaf::algorithm {
 namespace detail {
 
 template <typename WEIGHT_T>
-struct PathVertex {
+struct path_vertex {
   vertex_id_t id;
   WEIGHT_T dist_from_start;
   vertex_id_t prev_id;
 
-  [[nodiscard]] bool operator>(const PathVertex<WEIGHT_T>& other) {
+  [[nodiscard]] bool operator>(const path_vertex<WEIGHT_T>& other) {
     return dist_from_start > other.dist_from_start;
   }
 };
 
 template <typename WEIGHT_T>
-std::optional<GraphPath<WEIGHT_T>> reconstruct_path(
+std::optional<graph_path<WEIGHT_T>> reconstruct_path(
     vertex_id_t start_vertex, vertex_id_t end_vertex,
-    std::unordered_map<vertex_id_t, PathVertex<WEIGHT_T>>& vertex_info) {
+    std::unordered_map<vertex_id_t, path_vertex<WEIGHT_T>>& vertex_info) {
   if (!vertex_info.contains(end_vertex)) {
     return std::nullopt;
   }
 
-  GraphPath<WEIGHT_T> path;
+  graph_path<WEIGHT_T> path;
   auto current = end_vertex;
 
   while (current != start_vertex) {
@@ -45,10 +45,10 @@ std::optional<GraphPath<WEIGHT_T>> reconstruct_path(
 }  // namespace detail
 
 template <typename V, typename E, graph_type T, typename WEIGHT_T>
-std::optional<GraphPath<WEIGHT_T>> bfs_shortest_path(
+std::optional<graph_path<WEIGHT_T>> bfs_shortest_path(
     const graph<V, E, T>& graph, vertex_id_t start_vertex,
     vertex_id_t end_vertex) {
-  std::unordered_map<vertex_id_t, detail::PathVertex<WEIGHT_T>> vertex_info;
+  std::unordered_map<vertex_id_t, detail::path_vertex<WEIGHT_T>> vertex_info;
   std::queue<vertex_id_t> to_explore{};
 
   vertex_info[start_vertex] = {start_vertex, 1, start_vertex};
@@ -75,12 +75,12 @@ std::optional<GraphPath<WEIGHT_T>> bfs_shortest_path(
 }
 
 template <typename V, typename E, graph_type T, typename WEIGHT_T>
-std::optional<GraphPath<WEIGHT_T>> dijkstra_shortest_path(
+std::optional<graph_path<WEIGHT_T>> dijkstra_shortest_path(
     const graph<V, E, T>& graph, vertex_id_t start_vertex,
     vertex_id_t end_vertex) {
-  std::unordered_map<vertex_id_t, detail::PathVertex<WEIGHT_T>> vertex_info;
+  std::unordered_map<vertex_id_t, detail::path_vertex<WEIGHT_T>> vertex_info;
 
-  using weighted_path_item = detail::PathVertex<WEIGHT_T>;
+  using weighted_path_item = detail::path_vertex<WEIGHT_T>;
   std::priority_queue<weighted_path_item, std::vector<weighted_path_item>,
                       std::greater<>>
       to_explore{};

--- a/include/graaflib/properties/vertex_properties.h
+++ b/include/graaflib/properties/vertex_properties.h
@@ -6,16 +6,16 @@
 namespace graaf::properties {
 
 template <typename V, typename E, graph_type T>
-[[nodiscard]] std::size_t get_vertex_degree(const graaf::graph<V, E, T>& graph,
-                                            vertex_id_t vertex_id);
+[[nodiscard]] std::size_t vertex_degree(const graaf::graph<V, E, T>& graph,
+                                        vertex_id_t vertex_id);
 
 template <typename V, typename E, graph_type T>
-[[nodiscard]] std::size_t get_vertex_outdegree(
-    const graaf::graph<V, E, T>& graph, vertex_id_t vertex_id);
+[[nodiscard]] std::size_t vertex_outdegree(const graaf::graph<V, E, T>& graph,
+                                           vertex_id_t vertex_id);
 
 template <typename V, typename E, graph_type T>
-[[nodiscard]] std::size_t get_vertex_indegree(
-    const graaf::graph<V, E, T>& graph, vertex_id_t vertex_id);
+[[nodiscard]] std::size_t vertex_indegree(const graaf::graph<V, E, T>& graph,
+                                          vertex_id_t vertex_id);
 
 }  // namespace graaf::properties
 

--- a/include/graaflib/properties/vertex_properties.tpp
+++ b/include/graaflib/properties/vertex_properties.tpp
@@ -5,15 +5,15 @@
 namespace graaf::properties {
 
 template <typename V, typename E, graph_type T>
-std::size_t get_vertex_degree(const graaf::graph<V, E, T>& graph,
-                              vertex_id_t vertex_id) {
+std::size_t vertex_degree(const graaf::graph<V, E, T>& graph,
+                          vertex_id_t vertex_id) {
   if constexpr (T == graph_type::DIRECTED) {
-    return get_vertex_outdegree(graph, vertex_id) +
-           get_vertex_indegree(graph, vertex_id);
+    return vertex_outdegree(graph, vertex_id) +
+           vertex_indegree(graph, vertex_id);
   }
 
   if constexpr (T == graph_type::UNDIRECTED) {
-    return get_vertex_outdegree(graph, vertex_id);
+    return vertex_outdegree(graph, vertex_id);
   }
 
   // Should never reach this
@@ -21,14 +21,14 @@ std::size_t get_vertex_degree(const graaf::graph<V, E, T>& graph,
 }
 
 template <typename V, typename E, graph_type T>
-std::size_t get_vertex_outdegree(const graaf::graph<V, E, T>& graph,
-                                 vertex_id_t vertex_id) {
+std::size_t vertex_outdegree(const graaf::graph<V, E, T>& graph,
+                             vertex_id_t vertex_id) {
   return (graph.get_neighbors(vertex_id)).size();
 }
 
 template <typename V, typename E, graph_type T>
-std::size_t get_vertex_indegree(const graaf::graph<V, E, T>& graph,
-                                vertex_id_t vertex_id) {
+std::size_t vertex_indegree(const graaf::graph<V, E, T>& graph,
+                            vertex_id_t vertex_id) {
   using vertex_id_to_vertex_t = std::unordered_map<vertex_id_t, V>;
 
   if constexpr (T == graph_type::DIRECTED) {
@@ -42,7 +42,9 @@ std::size_t get_vertex_indegree(const graaf::graph<V, E, T>& graph,
   }
 
   if constexpr (T == graph_type::UNDIRECTED) {
-    return (graph.get_neighbors(vertex_id)).size();
+    // For an undirected graph, the indegree of a vertex is equal to the
+    // outdegree
+    return vertex_outdegree(graph, vertex_id);
   }
 
   // Should never reach this

--- a/test/graaflib/algorithm/cycle_detection_test.cpp
+++ b/test/graaflib/algorithm/cycle_detection_test.cpp
@@ -37,7 +37,7 @@ TYPED_TEST(GraphCycleTest, DirectedGraphWithCycle) {
   graph.add_edge(vertex_3, vertex_1, 300);
 
   // checking if graph contains cycles
-  bool cycle = has_cycle(graph);
+  bool cycle = dfs_cycle_detection(graph);
   ASSERT_TRUE(cycle);
 }
 
@@ -56,7 +56,7 @@ TYPED_TEST(GraphCycleTest, DirectedGraphWithCycleMiddle) {
   graph.add_edge(vertex_2, vertex_1, 300);
 
   // checking if graph contains cycle
-  bool cycle = has_cycle(graph);
+  bool cycle = dfs_cycle_detection(graph);
   ASSERT_TRUE(cycle);
 }
 
@@ -74,7 +74,7 @@ TYPED_TEST(GraphCycleTest, DirectedGraphWithoutCycle) {
   graph.add_edge(vertex_2, vertex_3, 300);
 
   // checking if graph contains cycle
-  bool cycle = has_cycle(graph);
+  bool cycle = dfs_cycle_detection(graph);
   ASSERT_FALSE(cycle);
 }
 
@@ -92,7 +92,7 @@ TYPED_TEST(GraphCycleTest, UndirectedGraphWithoutCycle) {
   graph.add_edge(vertex_2, vertex_3, 300);
 
   // checking if graph contains cycle
-  bool cycle = has_cycle(graph);
+  bool cycle = dfs_cycle_detection(graph);
   ASSERT_FALSE(cycle);
 }
 
@@ -111,7 +111,7 @@ TYPED_TEST(GraphCycleTest, UndirectedGraphWithCycle) {
   graph.add_edge(vertex_3, vertex_1, 400);
 
   // checking if graph contains cycle
-  bool cycle = has_cycle(graph);
+  bool cycle = dfs_cycle_detection(graph);
   ASSERT_TRUE(cycle);
 }
 
@@ -121,11 +121,11 @@ TYPED_TEST(GraphCycleTest, EmptyGraphs) {
   undirected_graph<int, int> undirected_graph{};
 
   // checking if graph contains cycles
-  bool cycle = has_cycle(directed_graph);
+  bool cycle = dfs_cycle_detection(directed_graph);
   ASSERT_FALSE(cycle);
 
   // checking  if graph contains cycles
-  cycle = has_cycle(undirected_graph);
+  cycle = dfs_cycle_detection(undirected_graph);
   ASSERT_FALSE(cycle);
 }
 
@@ -145,7 +145,7 @@ TYPED_TEST(GraphCycleTest, DefaultGraphWithCycle) {
   graph.add_edge(vertex_3, vertex_1, 400);
 
   // checking  if graph contains cycle
-  bool cycle = has_cycle(graph);
+  bool cycle = dfs_cycle_detection(graph);
   ASSERT_TRUE(cycle);
 }
 
@@ -164,7 +164,7 @@ TYPED_TEST(GraphCycleTest, DefaultGraphWithoutCycle) {
   graph.add_edge(vertex_2, vertex_3, 300);
 
   // checking if graph contains cycle
-  bool cycle = has_cycle(graph);
+  bool cycle = dfs_cycle_detection(graph);
   ASSERT_FALSE(cycle);
 }
 

--- a/test/graaflib/algorithm/graph_traversal_test.cpp
+++ b/test/graaflib/algorithm/graph_traversal_test.cpp
@@ -54,8 +54,8 @@ TYPED_TEST(TypedGraphTraversalTest, MinimalGraphDFS) {
   vertex_order_t vertex_order{};
 
   // WHEN
-  traverse<search_strategy::DFS>(
-      graph, vertex_1, record_vertex_callback{seen_vertices, vertex_order});
+  depth_first_traverse(graph, vertex_1,
+                       record_vertex_callback{seen_vertices, vertex_order});
 
   // THEN
   const seen_vertices_t expected_vertices{vertex_1};
@@ -73,8 +73,8 @@ TYPED_TEST(TypedGraphTraversalTest, MinimalGraphBFS) {
   vertex_order_t vertex_order{};
 
   // WHEN
-  traverse<search_strategy::BFS>(
-      graph, vertex_1, record_vertex_callback{seen_vertices, vertex_order});
+  breadth_first_traverse(graph, vertex_1,
+                         record_vertex_callback{seen_vertices, vertex_order});
 
   // THEN
   const seen_vertices_t expected_vertices{vertex_1};
@@ -97,8 +97,8 @@ TYPED_TEST(TypedGraphTraversalTest, SimpleGraphDFS) {
   vertex_order_t vertex_order{};
 
   // WHEN
-  traverse<search_strategy::DFS>(
-      graph, vertex_1, record_vertex_callback{seen_vertices, vertex_order});
+  depth_first_traverse(graph, vertex_1,
+                       record_vertex_callback{seen_vertices, vertex_order});
 
   // THEN - The order of traversal between neighbors is undefined
   const seen_vertices_t expected_vertices{vertex_1, vertex_2};
@@ -121,8 +121,8 @@ TYPED_TEST(TypedGraphTraversalTest, SimpleGraphBFS) {
   vertex_order_t vertex_order{};
 
   // WHEN
-  traverse<search_strategy::BFS>(
-      graph, vertex_1, record_vertex_callback{seen_vertices, vertex_order});
+  breadth_first_traverse(graph, vertex_1,
+                         record_vertex_callback{seen_vertices, vertex_order});
 
   // THEN - The order of traversal between neighbors is undefined
   const seen_vertices_t expected_vertices{vertex_1, vertex_2};
@@ -142,8 +142,8 @@ TEST(GraphTraversalTest, DirectedGraphEdgeWrongDirectionDFS) {
   vertex_order_t vertex_order{};
 
   // WHEN - here vertex 1 has no neighbors due to the edge direction
-  traverse<search_strategy::DFS>(
-      graph, vertex_1, record_vertex_callback{seen_vertices, vertex_order});
+  depth_first_traverse(graph, vertex_1,
+                       record_vertex_callback{seen_vertices, vertex_order});
 
   // THEN
   const seen_vertices_t expected_vertices{vertex_1};
@@ -163,8 +163,8 @@ TEST(GraphTraversalTest, DirectedGraphEdgeWrongDirectionBFS) {
   vertex_order_t vertex_order{};
 
   // WHEN - here vertex 1 has no neighbors due to the edge direction
-  traverse<search_strategy::BFS>(
-      graph, vertex_1, record_vertex_callback{seen_vertices, vertex_order});
+  breadth_first_traverse(graph, vertex_1,
+                         record_vertex_callback{seen_vertices, vertex_order});
 
   // THEN
   const seen_vertices_t expected_vertices{vertex_1};
@@ -193,8 +193,8 @@ TYPED_TEST(TypedGraphTraversalTest, MoreComplexGraphDFS) {
   vertex_order_t vertex_order{};
 
   // WHEN
-  traverse<search_strategy::DFS>(
-      graph, vertex_1, record_vertex_callback{seen_vertices, vertex_order});
+  depth_first_traverse(graph, vertex_1,
+                       record_vertex_callback{seen_vertices, vertex_order});
 
   // THEN
   const seen_vertices_t expected_vertices{vertex_1, vertex_2, vertex_3,
@@ -231,8 +231,8 @@ TYPED_TEST(TypedGraphTraversalTest, MoreComplexGraphBFS) {
   vertex_order_t vertex_order{};
 
   // WHEN
-  traverse<search_strategy::BFS>(
-      graph, vertex_1, record_vertex_callback{seen_vertices, vertex_order});
+  breadth_first_traverse(graph, vertex_1,
+                         record_vertex_callback{seen_vertices, vertex_order});
 
   // THEN
   const seen_vertices_t expected_vertices{vertex_1, vertex_2, vertex_3,
@@ -268,8 +268,8 @@ TEST(GraphTraversalTest, MoreComplexDirectedGraphEdgeWrongDirectionDFS) {
   vertex_order_t vertex_order{};
 
   // WHEN
-  traverse<search_strategy::DFS>(
-      graph, vertex_1, record_vertex_callback{seen_vertices, vertex_order});
+  depth_first_traverse(graph, vertex_1,
+                       record_vertex_callback{seen_vertices, vertex_order});
 
   // THEN
   const seen_vertices_t expected_vertices{vertex_1, vertex_2, vertex_3,
@@ -298,8 +298,8 @@ TEST(GraphTraversalTest, MoreComplexDirectedGraphEdgeWrongDirectionBFS) {
   vertex_order_t vertex_order{};
 
   // WHEN
-  traverse<search_strategy::BFS>(
-      graph, vertex_1, record_vertex_callback{seen_vertices, vertex_order});
+  breadth_first_traverse(graph, vertex_1,
+                         record_vertex_callback{seen_vertices, vertex_order});
 
   // THEN
   const seen_vertices_t expected_vertices{vertex_1, vertex_2, vertex_3,

--- a/test/graaflib/algorithm/shortest_path_test.cpp
+++ b/test/graaflib/algorithm/shortest_path_test.cpp
@@ -27,7 +27,7 @@ TYPED_TEST(TypedShortestPathTest, BfsMinimalShortestPath) {
   const auto path = bfs_shortest_path(graph, vertex_1, vertex_1);
 
   // THEN
-  const GraphPath<int> expected_path{{vertex_1}, 1};
+  const graph_path<int> expected_path{{vertex_1}, 1};
   ASSERT_EQ(path, expected_path);
 }
 
@@ -62,7 +62,7 @@ TYPED_TEST(TypedShortestPathTest, BfsSimpleShortestPath) {
   const auto path = bfs_shortest_path(graph, vertex_1, vertex_2);
 
   // THEN
-  const GraphPath<int> expected_path{{vertex_1, vertex_2}, 2};
+  const graph_path<int> expected_path{{vertex_1, vertex_2}, 2};
   ASSERT_EQ(path, expected_path);
 }
 
@@ -90,7 +90,7 @@ TYPED_TEST(TypedShortestPathTest, BfsMoreComplexShortestPath) {
   const auto path = bfs_shortest_path(graph, vertex_1, vertex_5);
 
   // THEN
-  const GraphPath<int> expected_path{{vertex_1, vertex_3, vertex_5}, 3};
+  const graph_path<int> expected_path{{vertex_1, vertex_3, vertex_5}, 3};
   ASSERT_EQ(path, expected_path);
 }
 
@@ -117,8 +117,8 @@ TYPED_TEST(TypedShortestPathTest, BfsCyclicShortestPath) {
   const auto path = bfs_shortest_path(graph, vertex_1, vertex_5);
 
   // THEN
-  const GraphPath<int> expected_path{{vertex_1, vertex_2, vertex_3, vertex_5},
-                                     4};
+  const graph_path<int> expected_path{{vertex_1, vertex_2, vertex_3, vertex_5},
+                                      4};
   ASSERT_EQ(path, expected_path);
 }
 
@@ -143,7 +143,7 @@ TEST(ShortestPathTest, BfsDirectedrWrongDirectionShortestPath) {
   const auto path = bfs_shortest_path(graph, vertex_1, vertex_5);
 
   // THEN
-  const GraphPath<int> expected_path{
+  const graph_path<int> expected_path{
       {vertex_1, vertex_2, vertex_4, vertex_3, vertex_5}, 5};
   ASSERT_EQ(path, expected_path);
 }
@@ -224,7 +224,7 @@ TYPED_TEST(DijkstraShortestPathTest, DijkstraMinimalShortestPath) {
   const auto path = dijkstra_shortest_path(graph, vertex_id_1, vertex_id_1);
 
   // THEN
-  const GraphPath<weight_t> expected_path{{vertex_id_1}, 0};
+  const graph_path<weight_t> expected_path{{vertex_id_1}, 0};
   ASSERT_EQ(path, expected_path);
 }
 
@@ -260,7 +260,7 @@ TYPED_TEST(DijkstraShortestPathTest, DijkstraSimpleShortestPath) {
   const auto path = dijkstra_shortest_path(graph, vertex_id_1, vertex_id_2);
 
   // THEN
-  const GraphPath<weight_t> expected_path{{vertex_id_1, vertex_id_2}, 3};
+  const graph_path<weight_t> expected_path{{vertex_id_1, vertex_id_2}, 3};
   ASSERT_EQ(path, expected_path);
 }
 
@@ -289,7 +289,7 @@ TYPED_TEST(DijkstraShortestPathTest, DijkstraMoreComplexShortestPath) {
   const auto path = dijkstra_shortest_path(graph, vertex_id_1, vertex_id_5);
 
   // THEN
-  const GraphPath<weight_t> expected_path{
+  const graph_path<weight_t> expected_path{
       {vertex_id_1, vertex_id_3, vertex_id_5}, 9};
   ASSERT_EQ(path, expected_path);
 }
@@ -318,7 +318,7 @@ TYPED_TEST(DijkstraShortestPathTest, DijkstraCyclicShortestPath) {
   const auto path = dijkstra_shortest_path(graph, vertex_id_1, vertex_id_5);
 
   // THEN
-  const GraphPath<weight_t> expected_path{
+  const graph_path<weight_t> expected_path{
       {vertex_id_1, vertex_id_2, vertex_id_3, vertex_id_5}, 8};
   ASSERT_EQ(path, expected_path);
 }

--- a/test/graaflib/algorithm/shortest_path_test.cpp
+++ b/test/graaflib/algorithm/shortest_path_test.cpp
@@ -16,7 +16,7 @@ using graph_types =
 TYPED_TEST_SUITE(TypedShortestPathTest, graph_types);
 }  // namespace
 
-TYPED_TEST(TypedShortestPathTest, UnweightedMinimalShortestPath) {
+TYPED_TEST(TypedShortestPathTest, BfsMinimalShortestPath) {
   // GIVEN
   using graph_t = typename TestFixture::graph_t;
   graph_t graph{};
@@ -24,15 +24,14 @@ TYPED_TEST(TypedShortestPathTest, UnweightedMinimalShortestPath) {
   const auto vertex_1{graph.add_vertex(10)};
 
   // WHEN
-  const auto path =
-      get_shortest_path<edge_strategy::UNWEIGHTED>(graph, vertex_1, vertex_1);
+  const auto path = bfs_shortest_path(graph, vertex_1, vertex_1);
 
   // THEN
   const GraphPath<int> expected_path{{vertex_1}, 1};
   ASSERT_EQ(path, expected_path);
 }
 
-TYPED_TEST(TypedShortestPathTest, UnweightedNoAvailablePath) {
+TYPED_TEST(TypedShortestPathTest, BfsNoAvailablePath) {
   // GIVEN
   using graph_t = typename TestFixture::graph_t;
   graph_t graph{};
@@ -41,14 +40,13 @@ TYPED_TEST(TypedShortestPathTest, UnweightedNoAvailablePath) {
   const auto vertex_2{graph.add_vertex(20)};
 
   // WHEN
-  const auto path =
-      get_shortest_path<edge_strategy::UNWEIGHTED>(graph, vertex_1, vertex_2);
+  const auto path = bfs_shortest_path(graph, vertex_1, vertex_2);
 
   // THEN
   ASSERT_FALSE(path.has_value());
 }
 
-TYPED_TEST(TypedShortestPathTest, UnweightedSimpleShortestPath) {
+TYPED_TEST(TypedShortestPathTest, BfsSimpleShortestPath) {
   // GIVEN
   using graph_t = typename TestFixture::graph_t;
   graph_t graph{};
@@ -61,15 +59,14 @@ TYPED_TEST(TypedShortestPathTest, UnweightedSimpleShortestPath) {
   graph.add_edge(vertex_1, vertex_2, 100);
 
   // WHEN
-  const auto path =
-      get_shortest_path<edge_strategy::UNWEIGHTED>(graph, vertex_1, vertex_2);
+  const auto path = bfs_shortest_path(graph, vertex_1, vertex_2);
 
   // THEN
   const GraphPath<int> expected_path{{vertex_1, vertex_2}, 2};
   ASSERT_EQ(path, expected_path);
 }
 
-TYPED_TEST(TypedShortestPathTest, UnweightedMoreComplexShortestPath) {
+TYPED_TEST(TypedShortestPathTest, BfsMoreComplexShortestPath) {
   // GIVEN
   using graph_t = typename TestFixture::graph_t;
   graph_t graph{};
@@ -90,15 +87,14 @@ TYPED_TEST(TypedShortestPathTest, UnweightedMoreComplexShortestPath) {
   graph.add_edge(vertex_3, vertex_5, 600);
 
   // WHEN
-  const auto path =
-      get_shortest_path<edge_strategy::UNWEIGHTED>(graph, vertex_1, vertex_5);
+  const auto path = bfs_shortest_path(graph, vertex_1, vertex_5);
 
   // THEN
   const GraphPath<int> expected_path{{vertex_1, vertex_3, vertex_5}, 3};
   ASSERT_EQ(path, expected_path);
 }
 
-TYPED_TEST(TypedShortestPathTest, UnweightedCyclicShortestPath) {
+TYPED_TEST(TypedShortestPathTest, BfsCyclicShortestPath) {
   // GIVEN
   using graph_t = typename TestFixture::graph_t;
   graph_t graph{};
@@ -118,8 +114,7 @@ TYPED_TEST(TypedShortestPathTest, UnweightedCyclicShortestPath) {
   graph.add_edge(vertex_3, vertex_5, 400);
 
   // WHEN
-  const auto path =
-      get_shortest_path<edge_strategy::UNWEIGHTED>(graph, vertex_1, vertex_5);
+  const auto path = bfs_shortest_path(graph, vertex_1, vertex_5);
 
   // THEN
   const GraphPath<int> expected_path{{vertex_1, vertex_2, vertex_3, vertex_5},
@@ -127,7 +122,7 @@ TYPED_TEST(TypedShortestPathTest, UnweightedCyclicShortestPath) {
   ASSERT_EQ(path, expected_path);
 }
 
-TEST(ShortestPathTest, UnweightedDirectedrWrongDirectionShortestPath) {
+TEST(ShortestPathTest, BfsDirectedrWrongDirectionShortestPath) {
   // GIVEN
   directed_graph<int, int> graph{};
 
@@ -145,8 +140,7 @@ TEST(ShortestPathTest, UnweightedDirectedrWrongDirectionShortestPath) {
   graph.add_edge(vertex_4, vertex_3, 500);
 
   // WHEN
-  const auto path =
-      get_shortest_path<edge_strategy::UNWEIGHTED>(graph, vertex_1, vertex_5);
+  const auto path = bfs_shortest_path(graph, vertex_1, vertex_5);
 
   // THEN
   const GraphPath<int> expected_path{
@@ -166,7 +160,7 @@ class my_weighted_edge : public weighted_edge<T> {
 };
 
 template <typename T>
-struct WeightedShortestPathTest : public testing::Test {
+struct DijkstraShortestPathTest : public testing::Test {
   using graph_t = typename T::first_type;
   using edge_t = typename T::second_type;
 };
@@ -214,9 +208,9 @@ using weighted_graph_types = testing::Types<
     std::pair<undirected_graph<int, my_weighted_edge<long double>>,
               my_weighted_edge<long double>>>;
 
-TYPED_TEST_SUITE(WeightedShortestPathTest, weighted_graph_types);
+TYPED_TEST_SUITE(DijkstraShortestPathTest, weighted_graph_types);
 
-TYPED_TEST(WeightedShortestPathTest, WeightedMinimalShortestPath) {
+TYPED_TEST(DijkstraShortestPathTest, DijkstraMinimalShortestPath) {
   // GIVEN
   using graph_t = typename TestFixture::graph_t;
   using edge_t = typename TestFixture::edge_t;
@@ -227,18 +221,16 @@ TYPED_TEST(WeightedShortestPathTest, WeightedMinimalShortestPath) {
   const auto vertex_id_1{graph.add_vertex(10)};
 
   // WHEN;
-  const auto path = get_shortest_path<edge_strategy::WEIGHTED>(
-      graph, vertex_id_1, vertex_id_1);
+  const auto path = dijkstra_shortest_path(graph, vertex_id_1, vertex_id_1);
 
   // THEN
   const GraphPath<weight_t> expected_path{{vertex_id_1}, 0};
   ASSERT_EQ(path, expected_path);
 }
 
-TYPED_TEST(WeightedShortestPathTest, WeightedNoAvailablePath) {
+TYPED_TEST(DijkstraShortestPathTest, DijkstraNoAvailablePath) {
   // GIVEN
   using graph_t = typename TestFixture::graph_t;
-  using edge_t = typename TestFixture::edge_t;
 
   graph_t graph{};
 
@@ -246,14 +238,13 @@ TYPED_TEST(WeightedShortestPathTest, WeightedNoAvailablePath) {
   const auto vertex_id_2{graph.add_vertex(20)};
 
   // WHEN;
-  const auto path = get_shortest_path<edge_strategy::WEIGHTED>(
-      graph, vertex_id_1, vertex_id_2);
+  const auto path = dijkstra_shortest_path(graph, vertex_id_1, vertex_id_2);
 
   // THEN
   ASSERT_FALSE(path.has_value());
 }
 
-TYPED_TEST(WeightedShortestPathTest, WeightedSimpleShortestPath) {
+TYPED_TEST(DijkstraShortestPathTest, DijkstraSimpleShortestPath) {
   // GIVEN
   using graph_t = typename TestFixture::graph_t;
   using edge_t = typename TestFixture::edge_t;
@@ -266,15 +257,14 @@ TYPED_TEST(WeightedShortestPathTest, WeightedSimpleShortestPath) {
   graph.add_edge(vertex_id_1, vertex_id_2, edge_t{static_cast<weight_t>(3)});
 
   // WHEN
-  const auto path = get_shortest_path<edge_strategy::WEIGHTED>(
-      graph, vertex_id_1, vertex_id_2);
+  const auto path = dijkstra_shortest_path(graph, vertex_id_1, vertex_id_2);
 
   // THEN
   const GraphPath<weight_t> expected_path{{vertex_id_1, vertex_id_2}, 3};
   ASSERT_EQ(path, expected_path);
 }
 
-TYPED_TEST(WeightedShortestPathTest, WeightedMoreComplexShortestPath) {
+TYPED_TEST(DijkstraShortestPathTest, DijkstraMoreComplexShortestPath) {
   // GIVEN
   using graph_t = typename TestFixture::graph_t;
   using edge_t = typename TestFixture::edge_t;
@@ -296,8 +286,7 @@ TYPED_TEST(WeightedShortestPathTest, WeightedMoreComplexShortestPath) {
   graph.add_edge(vertex_id_3, vertex_id_5, edge_t{static_cast<weight_t>(6)});
 
   // WHEN
-  const auto path = get_shortest_path<edge_strategy::WEIGHTED>(
-      graph, vertex_id_1, vertex_id_5);
+  const auto path = dijkstra_shortest_path(graph, vertex_id_1, vertex_id_5);
 
   // THEN
   const GraphPath<weight_t> expected_path{
@@ -305,7 +294,7 @@ TYPED_TEST(WeightedShortestPathTest, WeightedMoreComplexShortestPath) {
   ASSERT_EQ(path, expected_path);
 }
 
-TYPED_TEST(WeightedShortestPathTest, WeightedCyclicShortestPath) {
+TYPED_TEST(DijkstraShortestPathTest, DijkstraCyclicShortestPath) {
   // GIVEN
   using graph_t = typename TestFixture::graph_t;
   using edge_t = typename TestFixture::edge_t;
@@ -326,8 +315,7 @@ TYPED_TEST(WeightedShortestPathTest, WeightedCyclicShortestPath) {
   graph.add_edge(vertex_id_3, vertex_id_5, edge_t{static_cast<weight_t>(5)});
 
   // WHEN
-  const auto path = get_shortest_path<edge_strategy::WEIGHTED>(
-      graph, vertex_id_1, vertex_id_5);
+  const auto path = dijkstra_shortest_path(graph, vertex_id_1, vertex_id_5);
 
   // THEN
   const GraphPath<weight_t> expected_path{

--- a/test/graaflib/properties/vertex_properties_test.cpp
+++ b/test/graaflib/properties/vertex_properties_test.cpp
@@ -20,10 +20,10 @@ TEST(DirectedGraphPropertiesTest, VertexOutDegree) {
   graph.add_edge(vertex_id_2, vertex_id_4, 300);
 
   // THEN
-  ASSERT_EQ(get_vertex_outdegree(graph, vertex_id_1), 1);
-  ASSERT_EQ(get_vertex_outdegree(graph, vertex_id_2), 2);
-  ASSERT_EQ(get_vertex_outdegree(graph, vertex_id_3), 0);
-  ASSERT_EQ(get_vertex_outdegree(graph, vertex_id_4), 0);
+  ASSERT_EQ(vertex_outdegree(graph, vertex_id_1), 1);
+  ASSERT_EQ(vertex_outdegree(graph, vertex_id_2), 2);
+  ASSERT_EQ(vertex_outdegree(graph, vertex_id_3), 0);
+  ASSERT_EQ(vertex_outdegree(graph, vertex_id_4), 0);
 }
 
 TEST(DirectedGraphPropertiesTest, VertexInDegree) {
@@ -42,10 +42,10 @@ TEST(DirectedGraphPropertiesTest, VertexInDegree) {
   graph.add_edge(vertex_id_2, vertex_id_4, 400);
 
   // THEN
-  ASSERT_EQ(get_vertex_indegree(graph, vertex_id_1), 0);
-  ASSERT_EQ(get_vertex_indegree(graph, vertex_id_2), 1);
-  ASSERT_EQ(get_vertex_indegree(graph, vertex_id_3), 1);
-  ASSERT_EQ(get_vertex_indegree(graph, vertex_id_4), 2);
+  ASSERT_EQ(vertex_indegree(graph, vertex_id_1), 0);
+  ASSERT_EQ(vertex_indegree(graph, vertex_id_2), 1);
+  ASSERT_EQ(vertex_indegree(graph, vertex_id_3), 1);
+  ASSERT_EQ(vertex_indegree(graph, vertex_id_4), 2);
 }
 
 TEST(DirectedGraphPropertiesTest, VertexDegree) {
@@ -64,10 +64,10 @@ TEST(DirectedGraphPropertiesTest, VertexDegree) {
   graph.add_edge(vertex_id_2, vertex_id_4, 400);
 
   // THEN
-  ASSERT_EQ(get_vertex_degree(graph, vertex_id_1), 2);
-  ASSERT_EQ(get_vertex_degree(graph, vertex_id_2), 2);
-  ASSERT_EQ(get_vertex_degree(graph, vertex_id_3), 2);
-  ASSERT_EQ(get_vertex_degree(graph, vertex_id_4), 2);
+  ASSERT_EQ(vertex_degree(graph, vertex_id_1), 2);
+  ASSERT_EQ(vertex_degree(graph, vertex_id_2), 2);
+  ASSERT_EQ(vertex_degree(graph, vertex_id_3), 2);
+  ASSERT_EQ(vertex_degree(graph, vertex_id_4), 2);
 }
 
 TEST(UndirectedGraphPropertiesTest, VertexOutDegree) {
@@ -85,10 +85,10 @@ TEST(UndirectedGraphPropertiesTest, VertexOutDegree) {
   graph.add_edge(vertex_id_2, vertex_id_4, 300);
 
   // THEN
-  ASSERT_EQ(get_vertex_outdegree(graph, vertex_id_1), 1);
-  ASSERT_EQ(get_vertex_outdegree(graph, vertex_id_2), 3);
-  ASSERT_EQ(get_vertex_outdegree(graph, vertex_id_3), 1);
-  ASSERT_EQ(get_vertex_outdegree(graph, vertex_id_4), 1);
+  ASSERT_EQ(vertex_outdegree(graph, vertex_id_1), 1);
+  ASSERT_EQ(vertex_outdegree(graph, vertex_id_2), 3);
+  ASSERT_EQ(vertex_outdegree(graph, vertex_id_3), 1);
+  ASSERT_EQ(vertex_outdegree(graph, vertex_id_4), 1);
 }
 
 TEST(UndirectedGraphPropertiesTest, VertexInDegree) {
@@ -106,10 +106,10 @@ TEST(UndirectedGraphPropertiesTest, VertexInDegree) {
   graph.add_edge(vertex_id_2, vertex_id_4, 300);
 
   // THEN
-  ASSERT_EQ(get_vertex_indegree(graph, vertex_id_1), 1);
-  ASSERT_EQ(get_vertex_indegree(graph, vertex_id_2), 3);
-  ASSERT_EQ(get_vertex_indegree(graph, vertex_id_3), 1);
-  ASSERT_EQ(get_vertex_indegree(graph, vertex_id_4), 1);
+  ASSERT_EQ(vertex_indegree(graph, vertex_id_1), 1);
+  ASSERT_EQ(vertex_indegree(graph, vertex_id_2), 3);
+  ASSERT_EQ(vertex_indegree(graph, vertex_id_3), 1);
+  ASSERT_EQ(vertex_indegree(graph, vertex_id_4), 1);
 }
 
 TEST(UndirectedGraphPropertiesTest, VertexDegree) {
@@ -127,10 +127,10 @@ TEST(UndirectedGraphPropertiesTest, VertexDegree) {
   graph.add_edge(vertex_id_2, vertex_id_4, 300);
 
   // THEN
-  ASSERT_EQ(get_vertex_degree(graph, vertex_id_1), 1);
-  ASSERT_EQ(get_vertex_degree(graph, vertex_id_2), 3);
-  ASSERT_EQ(get_vertex_degree(graph, vertex_id_3), 1);
-  ASSERT_EQ(get_vertex_degree(graph, vertex_id_4), 1);
+  ASSERT_EQ(vertex_degree(graph, vertex_id_1), 1);
+  ASSERT_EQ(vertex_degree(graph, vertex_id_2), 3);
+  ASSERT_EQ(vertex_degree(graph, vertex_id_3), 1);
+  ASSERT_EQ(vertex_degree(graph, vertex_id_4), 1);
 }
 
 }  // namespace graaf::properties


### PR DESCRIPTION
Should be merged after #48 

This PR exposes the algorithm names to the user. For example, instead of calling `get_shortest_path`, the user now calls `dijkstra_shortest_path`. This should also make it easier to add new algorithms.