### PR TITLE
[ALGO] Dijkstra Shortest Path (Tree Version) (#54)

### DIFF
--- a/include/graaflib/algorithm/shortest_path.h
+++ b/include/graaflib/algorithm/shortest_path.h
@@ -49,6 +49,27 @@ std::optional<graph_path<WEIGHT_T>> dijkstra_shortest_path(
     const graph<V, E, T>& graph, vertex_id_t start_vertex,
     vertex_id_t end_vertex);
 
+/**
+ * Find the shortest paths from a source vertex to all other vertices in the
+ * graph using Dijkstra's algorithm.
+ *
+ * @tparam V The vertex type of the graph.
+ * @tparam E The edge type of the graph.
+ * @tparam T The graph type (directed or undirected).
+ * @tparam WEIGHT_T The type of edge weights.
+ * @param graph The graph we want to search.
+ * @param source_vertex The source vertex from which to compute shortest paths.
+ * @return A map containing the shortest paths from the source vertex to all
+ * other vertices. The map keys are target vertex IDs, and the values are
+ * instances of graph_path, representing the shortest distance and the path
+ * (list of vertex IDs) from the source to the target. If a vertex is not
+ * reachable from the source, its entry will be absent from the map.
+ */
+template <typename V, typename E, graph_type T,
+          typename WEIGHT_T = decltype(get_weight(std::declval<E>()))>
+[[nodiscard]] std::unordered_map<vertex_id_t, graph_path<WEIGHT_T>>
+dijkstra_shortest_paths(const graph<V, E, T>& graph, vertex_id_t source_vertex);
+
 }  // namespace graaf::algorithm
 
 #include "shortest_path.tpp"

--- a/include/graaflib/algorithm/shortest_path.tpp
+++ b/include/graaflib/algorithm/shortest_path.tpp
@@ -62,7 +62,7 @@ std::optional<graph_path<WEIGHT_T>> bfs_shortest_path(
       break;
     }
 
-    for (const auto& neighbor : graph.get_neighbors(current)) {
+    for (const auto neighbor : graph.get_neighbors(current)) {
       if (!vertex_info.contains(neighbor)) {
         vertex_info[neighbor] = {
             neighbor, vertex_info[current].dist_from_start + 1, current};
@@ -81,9 +81,10 @@ std::optional<graph_path<WEIGHT_T>> dijkstra_shortest_path(
   std::unordered_map<vertex_id_t, detail::path_vertex<WEIGHT_T>> vertex_info;
 
   using weighted_path_item = detail::path_vertex<WEIGHT_T>;
-  std::priority_queue<weighted_path_item, std::vector<weighted_path_item>,
-                      std::greater<>>
-      to_explore{};
+  using dijkstra_queue_t =
+      std::priority_queue<weighted_path_item, std::vector<weighted_path_item>,
+                          std::greater<>>;
+  dijkstra_queue_t to_explore{};
 
   vertex_info[start_vertex] = {start_vertex, 0, start_vertex};
   to_explore.push(vertex_info[start_vertex]);
@@ -131,16 +132,16 @@ dijkstra_shortest_paths(const graph<V, E, T>& graph,
     vertex_id_t curr_vertex_id = to_explore.top().second;
     to_explore.pop();
 
-    if (shortest_paths.find(curr_vertex_id) != shortest_paths.end() &&
+    if (shortest_paths.contains(curr_vertex_id) &&
         curr_distance > shortest_paths[curr_vertex_id].total_weight) {
       continue;
     }
 
-    for (const auto& neighbor : graph.get_neighbors(curr_vertex_id)) {
+    for (const auto neighbor : graph.get_neighbors(curr_vertex_id)) {
       WEIGHT_T distance =
           curr_distance + get_weight(graph.get_edge(curr_vertex_id, neighbor));
 
-      if (shortest_paths.find(neighbor) == shortest_paths.end() ||
+      if (!shortest_paths.contains(neighbor) ||
           distance < shortest_paths[neighbor].total_weight) {
         shortest_paths[neighbor].total_weight = distance;
         shortest_paths[neighbor].vertices =

--- a/include/graaflib/algorithm/shortest_path.tpp
+++ b/include/graaflib/algorithm/shortest_path.tpp
@@ -111,8 +111,7 @@ std::optional<graph_path<WEIGHT_T>> dijkstra_shortest_path(
   return reconstruct_path(start_vertex, end_vertex, vertex_info);
 }
 
-template <typename V, typename E, graph_type T,
-          typename WEIGHT_T = decltype(get_weight(std::declval<E>()))>
+template <typename V, typename E, graph_type T, typename WEIGHT_T>
 [[nodiscard]] std::unordered_map<vertex_id_t, graph_path<WEIGHT_T>>
 dijkstra_shortest_paths(const graph<V, E, T>& graph,
                         vertex_id_t source_vertex) {

--- a/test/graaflib/algorithm/shortest_path_test.cpp
+++ b/test/graaflib/algorithm/shortest_path_test.cpp
@@ -323,15 +323,7 @@ TYPED_TEST(DijkstraShortestPathTest, DijkstraCyclicShortestPath) {
   ASSERT_EQ(path, expected_path);
 }
 
-template <typename T>
-struct DijkstraShortestPathTreeTest : public testing::Test {
-  using graph_t = typename T::first_type;
-  using edge_t = typename T::second_type;
-};
-
-TYPED_TEST_SUITE(DijkstraShortestPathTreeTest, weighted_graph_types);
-
-TYPED_TEST(DijkstraShortestPathTreeTest, DijkstraMinimalShortestPathTree) {
+TYPED_TEST(DijkstraShortestPathTest, DijkstraMinimalShortestPathTree) {
   // GIVEN
   using graph_t = typename TestFixture::graph_t;
   using edge_t = typename TestFixture::edge_t;
@@ -351,7 +343,7 @@ TYPED_TEST(DijkstraShortestPathTreeTest, DijkstraMinimalShortestPathTree) {
   ASSERT_EQ(path_map, expected_path_map);
 }
 
-TYPED_TEST(DijkstraShortestPathTreeTest, DijkstraSimpleShortestPathTree) {
+TYPED_TEST(DijkstraShortestPathTest, DijkstraSimpleShortestPathTree) {
   // GIVEN
   using graph_t = typename TestFixture::graph_t;
   using edge_t = typename TestFixture::edge_t;
@@ -376,7 +368,7 @@ TYPED_TEST(DijkstraShortestPathTreeTest, DijkstraSimpleShortestPathTree) {
   ASSERT_EQ(path_map, expected_path_map);
 }
 
-TYPED_TEST(DijkstraShortestPathTreeTest, DijkstraMoreComplexShortestPathTree) {
+TYPED_TEST(DijkstraShortestPathTest, DijkstraMoreComplexShortestPathTree) {
   // GIVEN
   using graph_t = typename TestFixture::graph_t;
   using edge_t = typename TestFixture::edge_t;

--- a/test/graaflib/algorithm/shortest_path_test.cpp
+++ b/test/graaflib/algorithm/shortest_path_test.cpp
@@ -323,4 +323,99 @@ TYPED_TEST(DijkstraShortestPathTest, DijkstraCyclicShortestPath) {
   ASSERT_EQ(path, expected_path);
 }
 
+template <typename T>
+struct DijkstraShortestPathTreeTest : public testing::Test {
+  using graph_t = typename T::first_type;
+  using edge_t = typename T::second_type;
+};
+
+TYPED_TEST_SUITE(DijkstraShortestPathTreeTest, weighted_graph_types);
+
+TYPED_TEST(DijkstraShortestPathTreeTest, DijkstraMinimalShortestPathTree) {
+  // GIVEN
+  using graph_t = typename TestFixture::graph_t;
+  using edge_t = typename TestFixture::edge_t;
+  using weight_t = decltype(get_weight(std::declval<edge_t>()));
+
+  graph_t graph{};
+
+  const auto vertex_id_1{graph.add_vertex(10)};
+
+  // WHEN;
+  const auto path_map = dijkstra_shortest_paths(graph, vertex_id_1);
+
+  // THEN
+  const graph_path<weight_t> path1{{vertex_id_1}, 0};
+  std::unordered_map<vertex_id_t, graph_path<weight_t>> expected_path_map;
+  expected_path_map[vertex_id_1] = path1;
+  ASSERT_EQ(path_map, expected_path_map);
+}
+
+TYPED_TEST(DijkstraShortestPathTreeTest, DijkstraSimpleShortestPathTree) {
+  // GIVEN
+  using graph_t = typename TestFixture::graph_t;
+  using edge_t = typename TestFixture::edge_t;
+  using weight_t = decltype(get_weight(std::declval<edge_t>()));
+
+  graph_t graph{};
+
+  const auto vertex_id_1{graph.add_vertex(10)};
+  const auto vertex_id_2{graph.add_vertex(20)};
+  graph.add_edge(vertex_id_1, vertex_id_2, edge_t{static_cast<weight_t>(3)});
+
+  // WHEN
+  const auto path_map = dijkstra_shortest_paths(graph, vertex_id_1);
+
+  // THEN
+  const graph_path<weight_t> path1{{vertex_id_1}, 0};
+  const graph_path<weight_t> path2{{vertex_id_1, vertex_id_2}, 3};
+
+  std::unordered_map<vertex_id_t, graph_path<weight_t>> expected_path_map;
+  expected_path_map[vertex_id_1] = path1;
+  expected_path_map[vertex_id_2] = path2;
+  ASSERT_EQ(path_map, expected_path_map);
+}
+
+TYPED_TEST(DijkstraShortestPathTreeTest, DijkstraMoreComplexShortestPathTree) {
+  // GIVEN
+  using graph_t = typename TestFixture::graph_t;
+  using edge_t = typename TestFixture::edge_t;
+  using weight_t = decltype(get_weight(std::declval<edge_t>()));
+
+  graph_t graph{};
+
+  const auto vertex_id_1{graph.add_vertex(10)};
+  const auto vertex_id_2{graph.add_vertex(20)};
+  const auto vertex_id_3{graph.add_vertex(30)};
+  const auto vertex_id_4{graph.add_vertex(40)};
+  const auto vertex_id_5{graph.add_vertex(50)};
+
+  graph.add_edge(vertex_id_1, vertex_id_2, edge_t{static_cast<weight_t>(1)});
+  graph.add_edge(vertex_id_2, vertex_id_3, edge_t{static_cast<weight_t>(1)});
+  graph.add_edge(vertex_id_1, vertex_id_3, edge_t{static_cast<weight_t>(3)});
+  graph.add_edge(vertex_id_3, vertex_id_4, edge_t{static_cast<weight_t>(4)});
+  graph.add_edge(vertex_id_4, vertex_id_5, edge_t{static_cast<weight_t>(5)});
+  graph.add_edge(vertex_id_3, vertex_id_5, edge_t{static_cast<weight_t>(6)});
+
+  // WHEN
+  const auto path_map = dijkstra_shortest_paths(graph, vertex_id_1);
+
+  // THEN
+  const graph_path<weight_t> path1{{vertex_id_1}, 0};
+  const graph_path<weight_t> path2{{vertex_id_1, vertex_id_2}, 1};
+  const graph_path<weight_t> path3{{vertex_id_1, vertex_id_2, vertex_id_3}, 2};
+  const graph_path<weight_t> path4{
+      {vertex_id_1, vertex_id_2, vertex_id_3, vertex_id_4}, 6};
+  const graph_path<weight_t> path5{
+      {vertex_id_1, vertex_id_2, vertex_id_3, vertex_id_5}, 8};
+
+  std::unordered_map<vertex_id_t, graph_path<weight_t>> expected_path_map;
+  expected_path_map[vertex_id_1] = path1;
+  expected_path_map[vertex_id_2] = path2;
+  expected_path_map[vertex_id_3] = path3;
+  expected_path_map[vertex_id_4] = path4;
+  expected_path_map[vertex_id_5] = path5;
+  ASSERT_EQ(path_map, expected_path_map);
+}
+
 }  // namespace graaf::algorithm


### PR DESCRIPTION
Please note:

- This is not an exact overload of `dijkstra_shortest_path` as the syntax proposed in #54 uses the plural `paths`.
- There is quite some code duplication between the tree version and the non-tree version. The tree version would be able to cover both with an additional break statement, which is expected to have worse performance though. We could however think of trading some performance for readability and maintainability here.