### PR TITLE
breaking-change: Re-use graph traversal in bfs_shortest_path

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -4,3 +4,6 @@ coverage:
       default:
         target: 95%
         threshold: 5%
+    patch:
+      default:
+        target: 95%

--- a/include/graaflib/algorithm/graph_traversal.h
+++ b/include/graaflib/algorithm/graph_traversal.h
@@ -9,6 +9,13 @@ namespace graaf::algorithm {
 
 namespace detail {
 
+/**
+ * An edge callback which does nothing.
+ */
+struct noop_callback {
+  void operator()(const edge_id_t & /*edge*/) const {}
+};
+
 /*
  * A unary predicate which always returns false, effectively resulting in an
  * exhaustive search.
@@ -34,7 +41,8 @@ struct exhaustive_search_strategy {
  * predicate returns false.
  */
 template <
-    typename V, typename E, graph_type T, typename EDGE_CALLBACK_T,
+    typename V, typename E, graph_type T,
+    typename EDGE_CALLBACK_T = detail::noop_callback,
     typename SEARCH_TERMINATION_STRATEGY_T = detail::exhaustive_search_strategy>
   requires std::invocable<EDGE_CALLBACK_T &, edge_id_t &> &&
            std::is_invocable_r_v<bool, SEARCH_TERMINATION_STRATEGY_T &,
@@ -58,7 +66,8 @@ void breadth_first_traverse(
  * predicate returns false.
  */
 template <
-    typename V, typename E, graph_type T, typename EDGE_CALLBACK_T,
+    typename V, typename E, graph_type T,
+    typename EDGE_CALLBACK_T = detail::noop_callback,
     typename SEARCH_TERMINATION_STRATEGY_T = detail::exhaustive_search_strategy>
   requires std::invocable<EDGE_CALLBACK_T &, edge_id_t &> &&
            std::is_invocable_r_v<bool, SEARCH_TERMINATION_STRATEGY_T &,

--- a/include/graaflib/algorithm/graph_traversal.h
+++ b/include/graaflib/algorithm/graph_traversal.h
@@ -7,6 +7,20 @@
 
 namespace graaf::algorithm {
 
+namespace detail {
+
+/*
+ * A unary predicate which always returns false, effectively resulting in an
+ * exhaustive search.
+ */
+struct exhaustive_search_strategy {
+  [[nodiscard]] bool operator()(const vertex_id_t /*vertex*/) const {
+    return false;
+  }
+};
+
+}  // namespace detail
+
 /**
  * @brief Traverses the graph, starting at start_vertex, and visits all
  * reachable vertices in a BFS manner.
@@ -15,12 +29,21 @@ namespace graaf::algorithm {
  * @param start_vertex Vertex id where the traversal should be started.
  * @param callback A callback which is called for each traversed edge. Should
  * be invocable with an edge_id_t.
+ * @param search_termination_strategy A unary predicate to indicate whether we
+ * should continue the traversal or not. Traversal continues while this
+ * predicate returns false.
  */
-template <typename V, typename E, graph_type T, typename CALLBACK_T>
-  requires std::invocable<CALLBACK_T &, edge_id_t &>
-void breadth_first_traverse(const graph<V, E, T> &graph,
-                            vertex_id_t start_vertex,
-                            const CALLBACK_T &callback);
+template <
+    typename V, typename E, graph_type T, typename CALLBACK_T,
+    typename SEARCH_TERMINATION_STRATEGY_T = detail::exhaustive_search_strategy>
+  requires std::invocable<CALLBACK_T &, edge_id_t &> &&
+           std::is_invocable_r_v<bool, SEARCH_TERMINATION_STRATEGY_T &,
+                                 vertex_id_t>
+void breadth_first_traverse(
+    const graph<V, E, T> &graph, vertex_id_t start_vertex,
+    const CALLBACK_T &callback,
+    const SEARCH_TERMINATION_STRATEGY_T &search_termination_strategy =
+        SEARCH_TERMINATION_STRATEGY_T{});
 
 /**
  * @brief Traverses the graph, starting at start_vertex, and visits all
@@ -30,11 +53,21 @@ void breadth_first_traverse(const graph<V, E, T> &graph,
  * @param start_vertex Vertex id where the traversal should be started.
  * @param callback A callback which is called for each traversed edge. Should
  * be invocable with an edge_id_t.
+ * @param search_termination_strategy A unary predicate to indicate whether we
+ * should continue the traversal or not. Traversal continues while this
+ * predicate returns false.
  */
-template <typename V, typename E, graph_type T, typename CALLBACK_T>
-  requires std::invocable<CALLBACK_T &, edge_id_t &>
-void depth_first_traverse(const graph<V, E, T> &graph, vertex_id_t start_vertex,
-                          const CALLBACK_T &callback);
+template <
+    typename V, typename E, graph_type T, typename CALLBACK_T,
+    typename SEARCH_TERMINATION_STRATEGY_T = detail::exhaustive_search_strategy>
+  requires std::invocable<CALLBACK_T &, edge_id_t &> &&
+           std::is_invocable_r_v<bool, SEARCH_TERMINATION_STRATEGY_T &,
+                                 vertex_id_t>
+void depth_first_traverse(
+    const graph<V, E, T> &graph, vertex_id_t start_vertex,
+    const CALLBACK_T &callback,
+    const SEARCH_TERMINATION_STRATEGY_T &search_termination_strategy =
+        SEARCH_TERMINATION_STRATEGY_T{});
 
 }  // namespace graaf::algorithm
 

--- a/include/graaflib/algorithm/graph_traversal.h
+++ b/include/graaflib/algorithm/graph_traversal.h
@@ -27,21 +27,21 @@ struct exhaustive_search_strategy {
  *
  * @param graph The graph to traverse.
  * @param start_vertex Vertex id where the traversal should be started.
- * @param callback A callback which is called for each traversed edge. Should
- * be invocable with an edge_id_t.
+ * @param edge_callback A callback which is called for each traversed edge.
+ * Should be invocable with an edge_id_t.
  * @param search_termination_strategy A unary predicate to indicate whether we
  * should continue the traversal or not. Traversal continues while this
  * predicate returns false.
  */
 template <
-    typename V, typename E, graph_type T, typename CALLBACK_T,
+    typename V, typename E, graph_type T, typename EDGE_CALLBACK_T,
     typename SEARCH_TERMINATION_STRATEGY_T = detail::exhaustive_search_strategy>
-  requires std::invocable<CALLBACK_T &, edge_id_t &> &&
+  requires std::invocable<EDGE_CALLBACK_T &, edge_id_t &> &&
            std::is_invocable_r_v<bool, SEARCH_TERMINATION_STRATEGY_T &,
                                  vertex_id_t>
 void breadth_first_traverse(
     const graph<V, E, T> &graph, vertex_id_t start_vertex,
-    const CALLBACK_T &callback,
+    const EDGE_CALLBACK_T &edge_callback,
     const SEARCH_TERMINATION_STRATEGY_T &search_termination_strategy =
         SEARCH_TERMINATION_STRATEGY_T{});
 
@@ -51,21 +51,21 @@ void breadth_first_traverse(
  *
  * @param graph The graph to traverse.
  * @param start_vertex Vertex id where the traversal should be started.
- * @param callback A callback which is called for each traversed edge. Should
- * be invocable with an edge_id_t.
+ * @param edge_callback A callback which is called for each traversed edge.
+ * Should be invocable with an edge_id_t.
  * @param search_termination_strategy A unary predicate to indicate whether we
  * should continue the traversal or not. Traversal continues while this
  * predicate returns false.
  */
 template <
-    typename V, typename E, graph_type T, typename CALLBACK_T,
+    typename V, typename E, graph_type T, typename EDGE_CALLBACK_T,
     typename SEARCH_TERMINATION_STRATEGY_T = detail::exhaustive_search_strategy>
-  requires std::invocable<CALLBACK_T &, edge_id_t &> &&
+  requires std::invocable<EDGE_CALLBACK_T &, edge_id_t &> &&
            std::is_invocable_r_v<bool, SEARCH_TERMINATION_STRATEGY_T &,
                                  vertex_id_t>
 void depth_first_traverse(
     const graph<V, E, T> &graph, vertex_id_t start_vertex,
-    const CALLBACK_T &callback,
+    const EDGE_CALLBACK_T &edge_callback,
     const SEARCH_TERMINATION_STRATEGY_T &search_termination_strategy =
         SEARCH_TERMINATION_STRATEGY_T{});
 

--- a/include/graaflib/algorithm/graph_traversal.tpp
+++ b/include/graaflib/algorithm/graph_traversal.tpp
@@ -8,10 +8,12 @@ namespace graaf::algorithm {
 
 namespace detail {
 
-template <typename V, typename E, graph_type T, typename CALLBACK_T>
+template <typename V, typename E, graph_type T, typename CALLBACK_T,
+          typename SEARCH_TERMINATION_STRATEGY_T>
 void do_bfs(const graph<V, E, T>& graph,
             std::unordered_set<vertex_id_t>& seen_vertices,
-            vertex_id_t start_vertex, const CALLBACK_T& callback) {
+            vertex_id_t start_vertex, const CALLBACK_T& callback,
+            const SEARCH_TERMINATION_STRATEGY_T& search_termination_strategy) {
   std::queue<vertex_id_t> to_explore{};
 
   to_explore.push(start_vertex);
@@ -19,6 +21,10 @@ void do_bfs(const graph<V, E, T>& graph,
   while (!to_explore.empty()) {
     const auto current{to_explore.front()};
     to_explore.pop();
+
+    if (search_termination_strategy(current)) {
+      return;
+    }
 
     seen_vertices.insert(current);
     for (const auto neighbor_vertex : graph.get_neighbors(current)) {
@@ -30,37 +36,62 @@ void do_bfs(const graph<V, E, T>& graph,
   }
 }
 
-template <typename V, typename E, graph_type T, typename CALLBACK_T>
-void do_dfs(const graph<V, E, T>& graph,
+template <typename V, typename E, graph_type T, typename CALLBACK_T,
+          typename SEARCH_TERMINATION_STRATEGY_T>
+bool do_dfs(const graph<V, E, T>& graph,
             std::unordered_set<vertex_id_t>& seen_vertices, vertex_id_t current,
-            const CALLBACK_T& callback) {
+            const CALLBACK_T& callback,
+            const SEARCH_TERMINATION_STRATEGY_T& search_termination_strategy) {
   seen_vertices.insert(current);
+
+  if (search_termination_strategy(current)) {
+    return false;
+  }
 
   for (auto neighbor_vertex : graph.get_neighbors(current)) {
     if (!seen_vertices.contains(neighbor_vertex)) {
       callback(edge_id_t{current, neighbor_vertex});
-      do_dfs(graph, seen_vertices, neighbor_vertex, callback);
+      if (!do_dfs(graph, seen_vertices, neighbor_vertex, callback,
+                  search_termination_strategy)) {
+        // Further down the call stack we have hit the search termination point.
+        // Bubble this up the call stack.
+        return false;
+      }
     }
   }
+
+  // We did not hit the search termination point
+  return true;
 }
 
 }  // namespace detail
 
-template <typename V, typename E, graph_type T, typename CALLBACK_T>
-  requires std::invocable<CALLBACK_T&, edge_id_t&>
-void breadth_first_traverse(const graph<V, E, T>& graph,
-                            vertex_id_t start_vertex,
-                            const CALLBACK_T& callback) {
+template <typename V, typename E, graph_type T, typename CALLBACK_T,
+          typename SEARCH_TERMINATION_STRATEGY_T>
+  requires std::invocable<CALLBACK_T&, edge_id_t&> &&
+           std::is_invocable_r_v<bool, SEARCH_TERMINATION_STRATEGY_T&,
+                                 vertex_id_t>
+void breadth_first_traverse(
+    const graph<V, E, T>& graph, vertex_id_t start_vertex,
+    const CALLBACK_T& callback,
+    const SEARCH_TERMINATION_STRATEGY_T& search_termination_strategy) {
   std::unordered_set<vertex_id_t> seen_vertices{};
-  return detail::do_bfs(graph, seen_vertices, start_vertex, callback);
+  detail::do_bfs(graph, seen_vertices, start_vertex, callback,
+                 search_termination_strategy);
 }
 
-template <typename V, typename E, graph_type T, typename CALLBACK_T>
-  requires std::invocable<CALLBACK_T&, edge_id_t&>
-void depth_first_traverse(const graph<V, E, T>& graph, vertex_id_t start_vertex,
-                          const CALLBACK_T& callback) {
+template <typename V, typename E, graph_type T, typename CALLBACK_T,
+          typename SEARCH_TERMINATION_STRATEGY_T>
+  requires std::invocable<CALLBACK_T&, edge_id_t&> &&
+           std::is_invocable_r_v<bool, SEARCH_TERMINATION_STRATEGY_T&,
+                                 vertex_id_t>
+void depth_first_traverse(
+    const graph<V, E, T>& graph, vertex_id_t start_vertex,
+    const CALLBACK_T& callback,
+    const SEARCH_TERMINATION_STRATEGY_T& search_termination_strategy) {
   std::unordered_set<vertex_id_t> seen_vertices{};
-  return detail::do_dfs(graph, seen_vertices, start_vertex, callback);
+  detail::do_dfs(graph, seen_vertices, start_vertex, callback,
+                 search_termination_strategy);
 }
 
 }  // namespace graaf::algorithm

--- a/include/graaflib/algorithm/graph_traversal.tpp
+++ b/include/graaflib/algorithm/graph_traversal.tpp
@@ -8,12 +8,46 @@ namespace graaf::algorithm {
 
 namespace detail {
 
-template <typename V, typename E, graph_type T, typename CALLBACK_T,
+template <typename V, typename E, graph_type T, typename EDGE_CALLBACK_T,
           typename SEARCH_TERMINATION_STRATEGY_T>
-void do_bfs(const graph<V, E, T>& graph,
-            std::unordered_set<vertex_id_t>& seen_vertices,
-            vertex_id_t start_vertex, const CALLBACK_T& callback,
+bool do_dfs(const graph<V, E, T>& graph,
+            std::unordered_set<vertex_id_t>& seen_vertices, vertex_id_t current,
+            const EDGE_CALLBACK_T& edge_callback,
             const SEARCH_TERMINATION_STRATEGY_T& search_termination_strategy) {
+  seen_vertices.insert(current);
+
+  if (search_termination_strategy(current)) {
+    return false;
+  }
+
+  for (auto neighbor_vertex : graph.get_neighbors(current)) {
+    if (!seen_vertices.contains(neighbor_vertex)) {
+      edge_callback(edge_id_t{current, neighbor_vertex});
+      if (!do_dfs(graph, seen_vertices, neighbor_vertex, edge_callback,
+                  search_termination_strategy)) {
+        // Further down the call stack we have hit the search termination point.
+        // Bubble this up the call stack.
+        return false;
+      }
+    }
+  }
+
+  // We did not hit the search termination point
+  return true;
+}
+
+}  // namespace detail
+
+template <typename V, typename E, graph_type T, typename EDGE_CALLBACK_T,
+          typename SEARCH_TERMINATION_STRATEGY_T>
+  requires std::invocable<EDGE_CALLBACK_T&, edge_id_t&> &&
+           std::is_invocable_r_v<bool, SEARCH_TERMINATION_STRATEGY_T&,
+                                 vertex_id_t>
+void breadth_first_traverse(
+    const graph<V, E, T>& graph, vertex_id_t start_vertex,
+    const EDGE_CALLBACK_T& edge_callback,
+    const SEARCH_TERMINATION_STRATEGY_T& search_termination_strategy) {
+  std::unordered_set<vertex_id_t> seen_vertices{};
   std::queue<vertex_id_t> to_explore{};
 
   to_explore.push(start_vertex);
@@ -29,68 +63,24 @@ void do_bfs(const graph<V, E, T>& graph,
     seen_vertices.insert(current);
     for (const auto neighbor_vertex : graph.get_neighbors(current)) {
       if (!seen_vertices.contains(neighbor_vertex)) {
-        callback(edge_id_t{current, neighbor_vertex});
+        edge_callback(edge_id_t{current, neighbor_vertex});
         to_explore.push(neighbor_vertex);
       }
     }
   }
 }
 
-template <typename V, typename E, graph_type T, typename CALLBACK_T,
+template <typename V, typename E, graph_type T, typename EDGE_CALLBACK_T,
           typename SEARCH_TERMINATION_STRATEGY_T>
-bool do_dfs(const graph<V, E, T>& graph,
-            std::unordered_set<vertex_id_t>& seen_vertices, vertex_id_t current,
-            const CALLBACK_T& callback,
-            const SEARCH_TERMINATION_STRATEGY_T& search_termination_strategy) {
-  seen_vertices.insert(current);
-
-  if (search_termination_strategy(current)) {
-    return false;
-  }
-
-  for (auto neighbor_vertex : graph.get_neighbors(current)) {
-    if (!seen_vertices.contains(neighbor_vertex)) {
-      callback(edge_id_t{current, neighbor_vertex});
-      if (!do_dfs(graph, seen_vertices, neighbor_vertex, callback,
-                  search_termination_strategy)) {
-        // Further down the call stack we have hit the search termination point.
-        // Bubble this up the call stack.
-        return false;
-      }
-    }
-  }
-
-  // We did not hit the search termination point
-  return true;
-}
-
-}  // namespace detail
-
-template <typename V, typename E, graph_type T, typename CALLBACK_T,
-          typename SEARCH_TERMINATION_STRATEGY_T>
-  requires std::invocable<CALLBACK_T&, edge_id_t&> &&
-           std::is_invocable_r_v<bool, SEARCH_TERMINATION_STRATEGY_T&,
-                                 vertex_id_t>
-void breadth_first_traverse(
-    const graph<V, E, T>& graph, vertex_id_t start_vertex,
-    const CALLBACK_T& callback,
-    const SEARCH_TERMINATION_STRATEGY_T& search_termination_strategy) {
-  std::unordered_set<vertex_id_t> seen_vertices{};
-  detail::do_bfs(graph, seen_vertices, start_vertex, callback,
-                 search_termination_strategy);
-}
-
-template <typename V, typename E, graph_type T, typename CALLBACK_T,
-          typename SEARCH_TERMINATION_STRATEGY_T>
-  requires std::invocable<CALLBACK_T&, edge_id_t&> &&
+  requires std::invocable<EDGE_CALLBACK_T&, edge_id_t&> &&
            std::is_invocable_r_v<bool, SEARCH_TERMINATION_STRATEGY_T&,
                                  vertex_id_t>
 void depth_first_traverse(
     const graph<V, E, T>& graph, vertex_id_t start_vertex,
-    const CALLBACK_T& callback,
+    const EDGE_CALLBACK_T& edge_callback,
     const SEARCH_TERMINATION_STRATEGY_T& search_termination_strategy) {
   std::unordered_set<vertex_id_t> seen_vertices{};
-  detail::do_dfs(graph, seen_vertices, start_vertex, callback,
+  detail::do_dfs(graph, seen_vertices, start_vertex, edge_callback,
                  search_termination_strategy);
 }
 

--- a/test/graaflib/algorithm/graph_traversal_test.cpp
+++ b/test/graaflib/algorithm/graph_traversal_test.cpp
@@ -261,6 +261,104 @@ TYPED_TEST(TypedGraphTraversalTest, MoreComplexGraphBFS) {
                   edge_order.at({vertex_ids[2], vertex_ids[4]}));
 }
 
+TYPED_TEST(TypedGraphTraversalTest, MoreComplexGraphDFSImmediateTermination) {
+  // GIVEN
+  using graph_t = typename TestFixture::graph_t;
+  const auto [graph, vertex_ids]{create_complex_scenario<graph_t>()};
+
+  seen_edges_t seen_edges{};
+  edge_order_t edge_order{};
+
+  // Always returns true such that the search immediately terminates
+  const auto immediate_termination_strategy{
+      [](const vertex_id_t& /*vertex*/) { return true; }};
+
+  // WHEN
+  depth_first_traverse(graph, vertex_ids[0],
+                       record_edge_callback{seen_edges, edge_order},
+                       immediate_termination_strategy);
+
+  // THEN
+  const seen_edges_t expected_edges{};
+  ASSERT_EQ(seen_edges, expected_edges);
+}
+
+TYPED_TEST(TypedGraphTraversalTest, MoreComplexGraphBFSImmediateTermination) {
+  // GIVEN
+  using graph_t = typename TestFixture::graph_t;
+  const auto [graph, vertex_ids]{create_complex_scenario<graph_t>()};
+
+  seen_edges_t seen_edges{};
+  edge_order_t edge_order{};
+
+  // Always returns true such that the search immediately terminates
+  const auto immediate_termination_strategy{
+      [](const vertex_id_t& /*vertex*/) { return true; }};
+
+  // WHEN
+  breadth_first_traverse(graph, vertex_ids[0],
+                         record_edge_callback{seen_edges, edge_order},
+                         immediate_termination_strategy);
+
+  // THEN
+  const seen_edges_t expected_edges{};
+  ASSERT_EQ(seen_edges, expected_edges);
+}
+
+TYPED_TEST(TypedGraphTraversalTest, MoreComplexGraphDFSTermination) {
+  // GIVEN
+  using graph_t = typename TestFixture::graph_t;
+  const auto [graph, vertex_ids]{create_complex_scenario<graph_t>()};
+
+  seen_edges_t seen_edges{};
+  edge_order_t edge_order{};
+
+  const auto termination_strategy{
+      [target = vertex_ids[2]](const vertex_id_t& vertex) {
+        return vertex == target;
+      }};
+
+  // WHEN
+  breadth_first_traverse(graph, vertex_ids[0],
+                         record_edge_callback{seen_edges, edge_order},
+                         termination_strategy);
+
+  // THEN - Since there is no clear iteration order between the neighbors of the
+  // 0-th vertex, there are two options for which edges we traversed
+  const seen_edges_t expected_edges_option_1{{vertex_ids[0], vertex_ids[1]},
+                                             {vertex_ids[0], vertex_ids[2]}};
+  const seen_edges_t expected_edges_option_2{{vertex_ids[0], vertex_ids[2]}};
+  ASSERT_TRUE(seen_edges == expected_edges_option_1 ||
+              seen_edges == expected_edges_option_2);
+}
+
+TYPED_TEST(TypedGraphTraversalTest, MoreComplexGraphBFSTermination) {
+  // GIVEN
+  using graph_t = typename TestFixture::graph_t;
+  const auto [graph, vertex_ids]{create_complex_scenario<graph_t>()};
+
+  seen_edges_t seen_edges{};
+  edge_order_t edge_order{};
+
+  const auto termination_strategy{
+      [target = vertex_ids[2]](const vertex_id_t& vertex) {
+        return vertex == target;
+      }};
+
+  // WHEN
+  breadth_first_traverse(graph, vertex_ids[0],
+                         record_edge_callback{seen_edges, edge_order},
+                         termination_strategy);
+
+  // THEN - Since there is no clear iteration order between the neighbors of the
+  // 0-th vertex, there are two options for which edges we traversed
+  const seen_edges_t expected_edges_option_1{{vertex_ids[0], vertex_ids[1]},
+                                             {vertex_ids[0], vertex_ids[2]}};
+  const seen_edges_t expected_edges_option_2{{vertex_ids[0], vertex_ids[2]}};
+  ASSERT_TRUE(seen_edges == expected_edges_option_1 ||
+              seen_edges == expected_edges_option_2);
+}
+
 TEST(GraphTraversalTest, MoreComplexDirectedGraphEdgeWrongDirectionDFS) {
   // GIVEN
   directed_graph<int, int> graph{};

--- a/test/graaflib/algorithm/graph_traversal_test.cpp
+++ b/test/graaflib/algorithm/graph_traversal_test.cpp
@@ -332,6 +332,34 @@ TYPED_TEST(TypedGraphTraversalTest, MoreComplexGraphDFSTermination) {
               seen_edges == expected_edges_option_2);
 }
 
+TYPED_TEST(TypedGraphTraversalTest, MoreComplexGraphDFSLaterTermination) {
+  // GIVEN
+  using graph_t = typename TestFixture::graph_t;
+  const auto [graph, vertex_ids]{create_complex_scenario<graph_t>()};
+
+  seen_edges_t seen_edges{};
+  edge_order_t edge_order{};
+
+  // Here we terminate deeper in the tree
+  const auto termination_strategy{
+      [target = vertex_ids[3]](const vertex_id_t& vertex) {
+        return vertex == target;
+      }};
+
+  // WHEN
+  breadth_first_traverse(graph, vertex_ids[0],
+                         record_edge_callback{seen_edges, edge_order},
+                         termination_strategy);
+
+  // THEN - Since there is no clear iteration order between the neighbors of the
+  // 0-th vertex, but we must have AT_LEAST seen the following edges
+  const seen_edges_t expected_edges{{vertex_ids[0], vertex_ids[2]},
+                                    {vertex_ids[2], vertex_ids[3]}};
+  for (const auto& expected_edge : expected_edges) {
+    ASSERT_TRUE(seen_edges.contains(expected_edge));
+  }
+}
+
 TYPED_TEST(TypedGraphTraversalTest, MoreComplexGraphBFSTermination) {
   // GIVEN
   using graph_t = typename TestFixture::graph_t;

--- a/test/graaflib/algorithm/shortest_path_test.cpp
+++ b/test/graaflib/algorithm/shortest_path_test.cpp
@@ -27,7 +27,7 @@ TYPED_TEST(TypedShortestPathTest, BfsMinimalShortestPath) {
   const auto path = bfs_shortest_path(graph, vertex_1, vertex_1);
 
   // THEN
-  const graph_path<int> expected_path{{vertex_1}, 1};
+  const graph_path<int> expected_path{{vertex_1}, 0};
   ASSERT_EQ(path, expected_path);
 }
 
@@ -62,7 +62,7 @@ TYPED_TEST(TypedShortestPathTest, BfsSimpleShortestPath) {
   const auto path = bfs_shortest_path(graph, vertex_1, vertex_2);
 
   // THEN
-  const graph_path<int> expected_path{{vertex_1, vertex_2}, 2};
+  const graph_path<int> expected_path{{vertex_1, vertex_2}, 1};
   ASSERT_EQ(path, expected_path);
 }
 
@@ -90,7 +90,7 @@ TYPED_TEST(TypedShortestPathTest, BfsMoreComplexShortestPath) {
   const auto path = bfs_shortest_path(graph, vertex_1, vertex_5);
 
   // THEN
-  const graph_path<int> expected_path{{vertex_1, vertex_3, vertex_5}, 3};
+  const graph_path<int> expected_path{{vertex_1, vertex_3, vertex_5}, 2};
   ASSERT_EQ(path, expected_path);
 }
 
@@ -118,7 +118,7 @@ TYPED_TEST(TypedShortestPathTest, BfsCyclicShortestPath) {
 
   // THEN
   const graph_path<int> expected_path{{vertex_1, vertex_2, vertex_3, vertex_5},
-                                      4};
+                                      3};
   ASSERT_EQ(path, expected_path);
 }
 
@@ -144,7 +144,7 @@ TEST(ShortestPathTest, BfsDirectedrWrongDirectionShortestPath) {
 
   // THEN
   const graph_path<int> expected_path{
-      {vertex_1, vertex_2, vertex_4, vertex_3, vertex_5}, 5};
+      {vertex_1, vertex_2, vertex_4, vertex_3, vertex_5}, 4};
   ASSERT_EQ(path, expected_path);
 }
 


### PR DESCRIPTION
This PR does the following:
- Adds an optional `search_termination_strategy` to BFS and DFS
- Refactors `bfs_shortest_path` to make use of the existing `breadth_first_traverse`
- Fixes the expected path length in shortest path tests