### PR TITLE
Enhancement: Catch negative edge weights in dijkstra

### DIFF
--- a/include/graaflib/algorithm/shortest_path.tpp
+++ b/include/graaflib/algorithm/shortest_path.tpp
@@ -97,8 +97,15 @@ std::optional<graph_path<WEIGHT_T>> dijkstra_shortest_path(
     }
 
     for (const auto& neighbor : graph.get_neighbors(current.id)) {
-      WEIGHT_T distance = current.dist_from_start +
-                          get_weight(graph.get_edge(current.id, neighbor));
+      WEIGHT_T edge_weight = get_weight(graph.get_edge(current.id, neighbor));
+
+      if (edge_weight < 0) {
+        throw std::invalid_argument{fmt::format(
+            "Negative edge weight [{}] between vertices [{}] -> [{}].",
+            edge_weight, current.id, neighbor)};
+      }
+
+      WEIGHT_T distance = current.dist_from_start + edge_weight;
 
       if (!vertex_info.contains(neighbor) ||
           distance < vertex_info[neighbor].dist_from_start) {

--- a/test/graaflib/algorithm/shortest_path_test.cpp
+++ b/test/graaflib/algorithm/shortest_path_test.cpp
@@ -1,3 +1,4 @@
+#include <fmt/core.h>
 #include <graaflib/algorithm/shortest_path.h>
 #include <graaflib/graph.h>
 #include <graaflib/types.h>
@@ -410,4 +411,86 @@ TYPED_TEST(DijkstraShortestPathTest, DijkstraMoreComplexShortestPathTree) {
   ASSERT_EQ(path_map, expected_path_map);
 }
 
+template <typename T>
+struct DijkstraShortestPathSignedTypesTest : public testing::Test {
+  using graph_t = typename T::first_type;
+  using edge_t = typename T::second_type;
+};
+
+using weighted_graph_signed_types = testing::Types<
+
+    /**
+     * Primitive edge type directed graph
+     */
+    std::pair<directed_graph<int, int>, int>,
+    std::pair<directed_graph<int, float>, float>,
+    std::pair<directed_graph<int, long double>, long double>,
+
+    /**
+     * Non primitive weighted edge type directed graph
+     */
+
+    std::pair<directed_graph<int, my_weighted_edge<int>>,
+              my_weighted_edge<int>>,
+    std::pair<directed_graph<int, my_weighted_edge<float>>,
+              my_weighted_edge<float>>,
+    std::pair<directed_graph<int, my_weighted_edge<long double>>,
+              my_weighted_edge<long double>>,
+
+    /**
+     * Primitive edge type undirected graph
+     */
+    std::pair<undirected_graph<int, int>, int>,
+    std::pair<undirected_graph<int, float>, float>,
+    std::pair<undirected_graph<int, long double>, long double>,
+
+    /**
+     * Non primitive weighted edge type undirected graph
+     */
+    std::pair<undirected_graph<int, my_weighted_edge<int>>,
+              my_weighted_edge<int>>,
+    std::pair<undirected_graph<int, my_weighted_edge<float>>,
+              my_weighted_edge<float>>,
+    std::pair<undirected_graph<int, my_weighted_edge<long double>>,
+              my_weighted_edge<long double>>>;
+
+TYPED_TEST_SUITE(DijkstraShortestPathSignedTypesTest,
+                 weighted_graph_signed_types);
+
+TYPED_TEST(DijkstraShortestPathSignedTypesTest, DijkstraNegativeWeight) {
+  // GIVEN
+  using graph_t = typename TestFixture::graph_t;
+  using edge_t = typename TestFixture::edge_t;
+  using weight_t = decltype(get_weight(std::declval<edge_t>()));
+
+  graph_t graph{};
+
+  const auto vertex_id_1{graph.add_vertex(10)};
+  const auto vertex_id_2{graph.add_vertex(20)};
+  graph.add_edge(vertex_id_1, vertex_id_2, edge_t{static_cast<weight_t>(-1)});
+
+  //  THEN
+  ASSERT_THROW(
+      {
+        try {
+          // Call the get_edge function for non-existing vertices
+          [[maybe_unused]] const auto path{
+              dijkstra_shortest_path(graph, vertex_id_1, vertex_id_2)};
+          // If the above line doesn't throw an exception, fail the test
+          FAIL()
+              << "Expected std::invalid_argument exception, but no exception "
+                 "was thrown.";
+        } catch (const std::invalid_argument &ex) {
+          // Verify that the exception message contains the expected error
+          // message
+          EXPECT_EQ(
+              ex.what(),
+              fmt::format(
+                  "Negative edge weight [{}] between vertices [{}] -> [{}].",
+                  -1, vertex_id_1, vertex_id_2));
+          throw;
+        }
+      },
+      std::invalid_argument);
+}
 }  // namespace graaf::algorithm


### PR DESCRIPTION
Dijkstra's algorithm can't deal with negative edge weighs. Until now, we don't check this, which could lead to unexpected or misleading results. This PR fixes this by throwing an error on negative weights during the traversal.

The additional tests introduce some boilerplate code since we need to add a new type set that is purely signed. I'm open for feedback regarding more elegant ways to solve this!