### PR TITLE
add dockerFile && Dockerignore

### DIFF
--- a/.Dockerignore
+++ b/.Dockerignore
@@ -1,0 +1,7 @@
+build/
+
+# IDE
+.vscode/
+.cache/
+.vs/
+.idea

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+FROM ubuntu:22.04
+
+# Set environment variables to non-interactive (this prevents some prompts)
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install Clang, CMake, git, and other required tools
+RUN apt-get update && apt-get install -y \
+    clang \
+    cmake \
+    make \
+    git \
+    libstdc++-10-dev && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# Set the working directory 
+WORKDIR /usr/src/graaf
+
+# Copy the entire project to the working directory
+COPY . .
+
+# Build the project using CMake and Clang
+RUN mkdir build && cd build && \
+    cmake .. && \
+    cmake --build .
+
+CMD ["/bin/bash"]


### PR DESCRIPTION
In this PR, I've added a Dockerfile and .dockerignore to containerize the build process for the project.

Changes:
    `Dockerfile:` This file sets up an Ubuntu 22.04 environment, installs necessary dependencies, and builds the project using CMake and Clang.
    `.dockerignore:` To ensure only necessary files are copied into the Docker image and to exclude unnecessary files.