### PR TITLE
[TOOL] Add Dependabot for GitHub actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
I found this to be quite handy to keep gh actions up-to-date. We could think of extending it with checking cpp specific dependencies down the road as well.