### PR TITLE
Work on Edmonds-Karp algorithm

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ take a look at the [docs](https://bobluppes.github.io/graaf/docs/algorithms/intr
    - [Greedy Graph Coloring](https://bobluppes.github.io/graaf/docs/algorithms/coloring/greedy-graph-coloring)
 2. [**Cycle Detection Algorithms**](https://bobluppes.github.io/graaf/docs/category/cycle-detection-algorithms):
    - [DFS-Based Cycle Detection](https://bobluppes.github.io/graaf/docs/algorithms/cycle-detection/dfs-based)
+3. [**Maximum Flow Algorithms**](https://bobluppes.github.io/graaf/docs/category/maximum-flow)
+   - [Edmonds-Karp algorithm](https://bobluppes.github.io/graaf/docs/algorithms/aximum-flow/edmonds-karp)
 3. [**Minimum Spanning Tree (MST) Algorithms**](https://bobluppes.github.io/graaf/docs/category/minimum-spanning-tree)
    - [Kruskal's Algorithm](https://bobluppes.github.io/graaf/docs/algorithms/minimum-spanning-tree/kruskal)
    - [Prim's Algorithm](https://bobluppes.github.io/graaf/docs/algorithms/minimum-spanning-tree/prim)

--- a/README.md
+++ b/README.md
@@ -115,19 +115,19 @@ take a look at the [docs](https://bobluppes.github.io/graaf/docs/algorithms/intr
    - [DFS-Based Cycle Detection](https://bobluppes.github.io/graaf/docs/algorithms/cycle-detection/dfs-based)
 3. [**Maximum Flow Algorithms**](https://bobluppes.github.io/graaf/docs/category/maximum-flow)
    - [Edmonds-Karp algorithm](https://bobluppes.github.io/graaf/docs/algorithms/aximum-flow/edmonds-karp)
-3. [**Minimum Spanning Tree (MST) Algorithms**](https://bobluppes.github.io/graaf/docs/category/minimum-spanning-tree)
+4. [**Minimum Spanning Tree (MST) Algorithms**](https://bobluppes.github.io/graaf/docs/category/minimum-spanning-tree)
    - [Kruskal's Algorithm](https://bobluppes.github.io/graaf/docs/algorithms/minimum-spanning-tree/kruskal)
    - [Prim's Algorithm](https://bobluppes.github.io/graaf/docs/algorithms/minimum-spanning-tree/prim)
-4. [**Shortest Path Algorithms**](https://bobluppes.github.io/graaf/docs/category/shortest-path-algorithms):
+5. [**Shortest Path Algorithms**](https://bobluppes.github.io/graaf/docs/category/shortest-path-algorithms):
    - [A\* search](https://bobluppes.github.io/graaf/docs/algorithms/shortest-path/a-star)
    - [Bellman-Ford Shortest Path](https://bobluppes.github.io/graaf/docs/algorithms/shortest-path/bellman-ford)
    - [BFS-Based Shortest Path](https://bobluppes.github.io/graaf/docs/algorithms/shortest-path/bfs-based-shortest-path)
    - [Dijkstra Shortest Path](https://bobluppes.github.io/graaf/docs/algorithms/shortest-path/dijkstra)
    - [Floyd-Warshall Algorithm](https://bobluppes.github.io/graaf/docs/algorithms/shortest-path/floyd-warshall)
-5. [**Strongly Connected Components Algorithms**](https://bobluppes.github.io/graaf/docs/category/strongly-connected-component-algorithms):
+6. [**Strongly Connected Components Algorithms**](https://bobluppes.github.io/graaf/docs/category/strongly-connected-component-algorithms):
    - [Tarjan's Strongly Connected Components](https://bobluppes.github.io/graaf/docs/algorithms/strongly-connected-components/tarjan)
-6. [**Topological Sorting Algorithms**](https://bobluppes.github.io/graaf/docs/algorithms/topological-sort):
-7. [**Traversal Algorithms**](https://bobluppes.github.io/graaf/docs/category/traversal-algorithms):
+7. [**Topological Sorting Algorithms**](https://bobluppes.github.io/graaf/docs/algorithms/topological-sort):
+8. [**Traversal Algorithms**](https://bobluppes.github.io/graaf/docs/category/traversal-algorithms):
    - [Breadth-First Search (BFS)](https://bobluppes.github.io/graaf/docs/algorithms/traversal/breadth-first-search)
    - [Depth-First Search (DFS)](https://bobluppes.github.io/graaf/docs/algorithms/traversal/depth-first-search)
 

--- a/docs/docs/algorithms/maximum-flow/_category_.json
+++ b/docs/docs/algorithms/maximum-flow/_category_.json
@@ -1,0 +1,7 @@
+{
+    "label": "Maximum Flow Algorithms",
+    "link": {
+      "type": "generated-index"
+    }
+  }
+  

--- a/docs/docs/algorithms/maximum-flow/edmonds-karp.md
+++ b/docs/docs/algorithms/maximum-flow/edmonds-karp.md
@@ -1,0 +1,24 @@
+---
+sidebar_position: 3
+---
+
+# Edmonds-Karp Algorithm
+
+The Edmonds-Karp algorithm computes the maximum flow in a flow network.
+The Edmonds-Karp algorithm re-uses the existing `breadth_first_traverse` method for finding the shortest path that has available capacity. It runs in `O(|V||E|^2)` time, where `|V|` the number of vertices in the graph and `|E|` is the number of edges.
+
+[wikipedia](https://en.wikipedia.org/wiki/Edmonds%E2%80%93Karp_algorithm)
+
+## Syntax
+
+```cpp
+template <typename V, typename E, typename WEIGHT_T = decltype(get_weight(std::declval<E>()))>
+[[nodiscard]] WEIGHT_T edmonds_karp_max_flow(
+    const graph<V, E, graph_type::DIRECTED>& graph,
+    vertex_id_t source, vertex_id_t sink);
+```
+
+- **graph** The flow network graph.
+- **source** Vertex id where the flow network graph starts.
+- **sink** Vertex id where the flow network graph ends.
+- **return** The maximum flow value of the flow network graph.

--- a/docs/docs/algorithms/maximum-flow/edmonds-karp.md
+++ b/docs/docs/algorithms/maximum-flow/edmonds-karp.md
@@ -5,7 +5,6 @@ sidebar_position: 3
 # Edmonds-Karp Algorithm
 
 The Edmonds-Karp algorithm computes the maximum flow in a flow network.
-The Edmonds-Karp algorithm re-uses the existing `breadth_first_traverse` method for finding the shortest path that has available capacity. It runs in `O(|V||E|^2)` time, where `|V|` the number of vertices in the graph and `|E|` is the number of edges.
 
 [wikipedia](https://en.wikipedia.org/wiki/Edmonds%E2%80%93Karp_algorithm)
 

--- a/docs/docs/algorithms/maximum-flow/edmonds-karp.md
+++ b/docs/docs/algorithms/maximum-flow/edmonds-karp.md
@@ -5,6 +5,7 @@ sidebar_position: 3
 # Edmonds-Karp Algorithm
 
 The Edmonds-Karp algorithm computes the maximum flow in a flow network.
+At this moent, the Edmonds-Karp algorithm doesn't re-use the existing `breadth_first_traverse` method for finding the shortest path that has available capacity.
 
 [wikipedia](https://en.wikipedia.org/wiki/Edmonds%E2%80%93Karp_algorithm)
 

--- a/include/graaflib/algorithm/maximum_flow/edmonds_karp.h
+++ b/include/graaflib/algorithm/maximum_flow/edmonds_karp.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <graaflib/graph.h>
+#include <graaflib/types.h>
+
+namespace graaf::algorithm {
+
+/**
+ * @brief Computes the maximum flow in a flow network using the Edmonds-Karp
+ * algorithm.
+ *
+ * This algorithm finds the maximum flow in a flow network from a source vertex
+ * to a sink vertex.
+ *
+ * @param graph The flow network graph.
+ * @param source The source vertex.
+ * @param sink The sink vertex.
+ * @return The maximum flow value.
+ */
+template <typename V, typename E,
+          typename WEIGHT_T = decltype(get_weight(std::declval<E>()))>
+[[nodiscard]] WEIGHT_T edmonds_karp_max_flow(
+    const graph<V, E, graph_type::DIRECTED>& graph, vertex_id_t source,
+    vertex_id_t sink);
+
+}  // namespace graaf::algorithm
+
+#include "edmonds_karp.tpp"

--- a/include/graaflib/algorithm/maximum_flow/edmonds_karp.tpp
+++ b/include/graaflib/algorithm/maximum_flow/edmonds_karp.tpp
@@ -1,0 +1,100 @@
+#pragma once
+
+#include <graaflib/algorithm/maximum_flow/edmonds_karp.h>
+#include <graaflib/algorithm/maximum_flow/residual_graph.h>
+#include <graaflib/types.h>
+
+#include <queue>
+#include <unordered_map>
+
+namespace graaf::algorithm {
+
+// Helper function for the Edmonds-Karp algorithm to find augmenting paths using
+// BFS.
+template <typename V, typename E, typename WEIGHT_T>
+[[nodiscard]] WEIGHT_T find_augmenting_path(
+    residual_graph_adapter_t<V, E, WEIGHT_T>& residual_graph,
+    vertex_id_t source, vertex_id_t sink,
+    std::unordered_map<vertex_id_t, vertex_id_t>& parent) {
+  // Create a queue for BFS traversal starting from the source vertex.
+  std::queue<vertex_id_t> bfs_queue;
+  bfs_queue.push(source);
+
+  // Create a set to keep track of visited vertices.
+  std::unordered_set<vertex_id_t> visited;
+  visited.insert(source);
+
+  // Create a map to store the parent vertex for each visited vertex.
+  parent.clear();
+  parent[source] = source;  // The source is its own parent.
+
+  // Perform BFS to find an augmenting path.
+  while (!bfs_queue.empty()) {
+    vertex_id_t current = bfs_queue.front();
+    bfs_queue.pop();
+
+    // Iterate over the neighbors of the current vertex.
+    for (const auto& neighbor : residual_graph.get_neighbors(current)) {
+      // Check if the neighbor has not been visited and has residual capacity.
+      if (!visited.count(neighbor) &&
+          residual_graph.has_residual_capacity(current, neighbor)) {
+        // Set the parent of the neighbor to the current vertex.
+        parent[neighbor] = current;
+
+        // Mark the neighbor as visited and add it to the BFS queue.
+        visited.insert(neighbor);
+        bfs_queue.push(neighbor);
+
+        // If the neighbor is the sink vertex, we have found an augmenting path.
+        if (neighbor == sink) {
+          // Calculate the minimum residual capacity along the path (path_flow).
+          WEIGHT_T path_flow = std::numeric_limits<WEIGHT_T>::max();
+          vertex_id_t v = sink;
+          while (v != source) {
+            vertex_id_t u = parent[v];
+            path_flow =
+                std::min(path_flow, residual_graph.get_residual_capacity(u, v));
+            v = u;
+          }
+          return path_flow;  // Return the maximum flow that can be added along
+                             // this path.
+        }
+      }
+    }
+  }
+
+  // No augmenting path found
+  return 0;
+}
+
+// Edmonds-Karp algorithm for maximum flow
+template <typename V, typename E, typename WEIGHT_T>
+[[nodiscord]] WEIGHT_T edmonds_karp_max_flow(
+    const graph<V, E, graph_type::DIRECTED>& graph, vertex_id_t source,
+    vertex_id_t sink) {
+  // Initialize flow and residual graph
+  WEIGHT_T max_flow = WEIGHT_T(0);
+  residual_graph_adapter_t<V, E, WEIGHT_T> residual_graph(graph);
+
+  // Keep track of parent vertices for path reconstruction
+  std::unordered_map<vertex_id_t, vertex_id_t> parent;
+  WEIGHT_T path_flow;
+  while ((path_flow =
+              find_augmenting_path(residual_graph, source, sink, parent)) > 0) {
+    max_flow += path_flow;
+
+    // Update residual capacities along the augmenting path
+    vertex_id_t v = sink;
+    while (v != source) {
+      vertex_id_t u = parent[v];
+      residual_graph.update_residual_capacity(u, v, path_flow);
+      residual_graph.update_residual_capacity(v, u,
+                                              -path_flow);  // Reverse edge
+      v = u;
+    }
+  }
+
+  return max_flow;
+}
+
+}  // namespace graaf::algorithm

--- a/include/graaflib/algorithm/maximum_flow/residual_graph.h
+++ b/include/graaflib/algorithm/maximum_flow/residual_graph.h
@@ -1,0 +1,54 @@
+#include <graaflib/graph.h>
+
+#include <limits>
+#include <queue>
+#include <unordered_map>
+#include <vector>
+
+namespace graaf {
+
+// Define an adapter class to hold residual capacities.
+template <typename V, typename E, typename WEIGHT_T>
+class residual_graph_adapter_t {
+ public:
+  using vertices_t = std::unordered_set<vertex_id_t>;
+  residual_graph_adapter_t(
+      const graph<V, E, graph_type::DIRECTED>& originalGraph)
+      : original_graph(originalGraph) {
+    // Initialize the residual capacities based on the original graph.
+    for (const auto& [edge_id, edge] : original_graph.get_edges()) {
+      residual_capacities[edge_id] = get_weight(edge);
+    }
+  }
+
+  // Define functions to access the residual capacities.
+  WEIGHT_T get_residual_capacity(vertex_id_t from, vertex_id_t to) const {
+    const auto edge_id = std::make_pair(from, to);
+    if (residual_capacities.count(edge_id)) {
+      return residual_capacities.at(edge_id);
+    }
+    return 0;
+  }
+
+  void update_residual_capacity(vertex_id_t from, vertex_id_t to,
+                                WEIGHT_T capacity) {
+    const auto edge_id = std::make_pair(from, to);
+    if (residual_capacities.count(edge_id)) {
+      residual_capacities[edge_id] -= capacity;
+    }
+  }
+
+  bool has_residual_capacity(vertex_id_t from, vertex_id_t to) const {
+    return get_residual_capacity(from, to) > 0;
+  }
+
+  [[nodiscard]] vertices_t get_neighbors(vertex_id_t vertex_id) const {
+    return original_graph.get_neighbors(vertex_id);
+  }
+
+ private:
+  const graph<V, E, graph_type::DIRECTED>& original_graph;
+  std::unordered_map<edge_id_t, WEIGHT_T, edge_id_hash> residual_capacities;
+};
+
+}  // namespace graaf

--- a/test/graaflib/algorithm/maximum_flow/edmonds_karp_maximum_flow_test.cpp
+++ b/test/graaflib/algorithm/maximum_flow/edmonds_karp_maximum_flow_test.cpp
@@ -1,0 +1,165 @@
+#include <graaflib/algorithm/maximum_flow/edmonds_karp.h>
+#include <graaflib/graph.h>
+#include <graaflib/types.h>
+#include <gtest/gtest.h>
+
+namespace graaf::algorithm {
+
+namespace {
+template <typename T>
+struct TypedMaximumFlowTest : public testing::Test {
+  using graph_t = T;
+};
+
+using graph_types =
+    testing::Types<directed_graph<int, int>, undirected_graph<int, int>>;
+
+TYPED_TEST_SUITE(TypedMaximumFlowTest, graph_types);
+
+}  // namespace
+
+template <typename T>
+class my_weighted_edge : public weighted_edge<T> {
+ public:
+  explicit my_weighted_edge(T weight) : weight_{weight} {}
+
+  [[nodiscard]] T get_weight() const noexcept override { return weight_; }
+
+ private:
+  T weight_{};
+};
+
+template <typename T>
+struct EdmondsKarpMaximumFlowTest : public testing::Test {
+  using graph_t = typename T::first_type;
+  using edge_t = typename T::second_type;
+};
+
+using weighted_graph_types = testing::Types<
+
+    /**
+     * Primitive edge type directed graph
+     */
+    std::pair<directed_graph<int, int>, int>,
+    std::pair<directed_graph<int, unsigned long>, unsigned long>,
+    std::pair<directed_graph<int, float>, float>,
+    std::pair<directed_graph<int, long double>, long double>,
+
+    /**
+     * Non primitive weighted edge type directed graph
+     */
+
+    std::pair<directed_graph<int, my_weighted_edge<int>>,
+              my_weighted_edge<int>>,
+    std::pair<directed_graph<int, my_weighted_edge<unsigned long>>,
+              my_weighted_edge<unsigned long>>,
+    std::pair<directed_graph<int, my_weighted_edge<float>>,
+              my_weighted_edge<float>>,
+    std::pair<directed_graph<int, my_weighted_edge<long double>>,
+              my_weighted_edge<long double>>>;
+
+TYPED_TEST_SUITE(EdmondsKarpMaximumFlowTest, weighted_graph_types);
+
+TYPED_TEST(EdmondsKarpMaximumFlowTest, EdmondsKarpGraphWithoutFlowTest) {
+  // GIVEN
+  using graph_t = typename TestFixture::graph_t;
+  using edge_t = typename TestFixture::edge_t;
+  using weight_t = decltype(get_weight(std::declval<edge_t>()));
+
+  graph_t graph{};
+
+  const auto source = graph.add_vertex(10);
+  const auto v1 = graph.add_vertex(20);
+  const auto sink = graph.add_vertex(30);
+
+  // All capacities are zero.
+  graph.add_edge(source, v1, edge_t{static_cast<weight_t>(0)});
+  graph.add_edge(v1, sink, edge_t{static_cast<weight_t>(0)});
+
+  // Calculate manually the expected maximum flow value
+  weight_t expected_max_flow = static_cast<weight_t>(0);  // No feasible flow
+
+  // WHEN
+  auto max_flow_value = edmonds_karp_max_flow(graph, source, sink);
+
+  // THEN
+  ASSERT_EQ(max_flow_value, expected_max_flow);
+}
+
+// Example from Baeldung
+// https://www.baeldung.com/cs/network-flow-edmonds-karp-algorithm
+TYPED_TEST(EdmondsKarpMaximumFlowTest, EdmondsKarpFlowNetworkTest) {
+  // GIVEN
+  using graph_t = typename TestFixture::graph_t;
+  using edge_t = typename TestFixture::edge_t;
+  using weight_t = decltype(get_weight(std::declval<edge_t>()));
+
+  graph_t graph{};
+
+  const auto source{graph.add_vertex(10)};
+  const auto v1{graph.add_vertex(20)};
+  const auto v2{graph.add_vertex(30)};
+  const auto v3{graph.add_vertex(40)};
+  const auto v4{graph.add_vertex(50)};
+  const auto sink{graph.add_vertex(60)};
+
+  graph.add_edge(source, v1, edge_t{static_cast<weight_t>(15)});
+  graph.add_edge(source, v2, edge_t{static_cast<weight_t>(12)});
+  graph.add_edge(v2, v1, edge_t{static_cast<weight_t>(10)});
+  graph.add_edge(v1, v3, edge_t{static_cast<weight_t>(10)});
+  graph.add_edge(v2, v3, edge_t{static_cast<weight_t>(5)});
+  graph.add_edge(v4, v2, edge_t{static_cast<weight_t>(6)});
+  graph.add_edge(v3, v4, edge_t{static_cast<weight_t>(8)});
+  graph.add_edge(v3, sink, edge_t{static_cast<weight_t>(8)});
+  graph.add_edge(v4, sink, edge_t{static_cast<weight_t>(13)});
+
+  // Calculate manually the expected maximum flow value
+  weight_t expected_max_flow = static_cast<weight_t>(15);
+
+  // WHEN
+  auto max_flow_value = edmonds_karp_max_flow(graph, source, sink);
+
+  // THEN
+  ASSERT_EQ(max_flow_value, expected_max_flow);
+}
+
+// Example from wikipedia article on Edmonds-Karp
+TYPED_TEST(EdmondsKarpMaximumFlowTest, EdmondsKarpFlowNetwork2Test) {
+  // GIVEN
+  using graph_t = typename TestFixture::graph_t;
+  using edge_t = typename TestFixture::edge_t;
+  using weight_t = decltype(get_weight(std::declval<edge_t>()));
+
+  graph_t graph{};
+
+  const auto a{graph.add_vertex(10)};
+  const auto b{graph.add_vertex(20)};
+  const auto c{graph.add_vertex(30)};
+  const auto d{graph.add_vertex(40)};
+  const auto e{graph.add_vertex(50)};
+  const auto f{graph.add_vertex(60)};
+  const auto g{graph.add_vertex(70)};
+
+  graph.add_edge(a, b, edge_t{static_cast<weight_t>(3)});
+  graph.add_edge(a, d, edge_t{static_cast<weight_t>(3)});
+  graph.add_edge(b, c, edge_t{static_cast<weight_t>(4)});
+  graph.add_edge(c, a, edge_t{static_cast<weight_t>(3)});
+  graph.add_edge(c, d, edge_t{static_cast<weight_t>(1)});
+  graph.add_edge(c, e, edge_t{static_cast<weight_t>(2)});
+  graph.add_edge(e, b, edge_t{static_cast<weight_t>(1)});
+  graph.add_edge(d, e, edge_t{static_cast<weight_t>(2)});
+  graph.add_edge(d, f, edge_t{static_cast<weight_t>(6)});
+  graph.add_edge(f, g, edge_t{static_cast<weight_t>(9)});
+  graph.add_edge(e, g, edge_t{static_cast<weight_t>(1)});
+
+  // Calculate manually the expected maximum flow value
+  weight_t expected_max_flow = static_cast<weight_t>(5);
+
+  // WHEN
+  auto max_flow_value = edmonds_karp_max_flow(graph, a, g);
+
+  // THEN
+  ASSERT_EQ(max_flow_value, expected_max_flow);
+}
+
+}  // namespace graaf::algorithm


### PR DESCRIPTION
See https://github.com/bobluppes/graaf/issues/83

* Documentation entry can be extended
* More unit tests could be added
* It doesn't re-use the existing BF method, because I found it easier to implement the algorithm without it.
* The algorithm uses a residual_graph_adapter_t structure. Maybe the location of this file could be better somewhere else.
* In residual_graph.h, I am not sure whether I used the get_edges and get_weight methods in the correct way (with [edge_id, edge]  and residual_capacities[edge_id]).