### PR TITLE
[TEMP FIX] Remove clang build from CI

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        compiler: [g++, clang++]
+        compiler: [g++]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Due to https://github.com/actions/runner-images/issues/8659, all of our CIs fail in the build stage for clang (see [here](https://github.com/bobluppes/graaf/actions/runs/6610675272/job/18094285713#step:4:1)  for example).
My recommendation would be dropping the clang build from the CI temporarily until the runner image is fixed. We would then test with g++ only. In the current CI config, the g++ does not even start if the clang fails.