### PR TITLE
[TOOL] Clean Python dependencies

### DIFF
--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -1,15 +1,3 @@
-contourpy==1.1.0
-cycler==0.11.0
-fonttools==4.41.1
-kiwisolver==1.4.4
 matplotlib==3.7.2
-numpy==1.25.1
-packaging==23.1
 pandas==2.0.3
-Pillow==10.0.1
-pyparsing==3.0.9
-python-dateutil==2.8.2
-pytz==2023.3
 seaborn==0.12.2
-six==1.16.0
-tzdata==2023.3

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -1,3 +1,3 @@
-matplotlib==3.7.2
-pandas==2.0.3
-seaborn==0.12.2
+matplotlib>=3.7.2
+pandas>=2.0.3
+seaborn>=0.12.2


### PR DESCRIPTION
Removes unnecessary Python dependencies. Will prevent dependabot from opening PRs like https://github.com/bobluppes/graaf/pull/188 and https://github.com/bobluppes/graaf/pull/191.