### PR TITLE
CMake Targets for FetchContent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 build/
 cmake-modules/
 venv
+cmake-build-debug
 
 # IDE
 .vscode/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,8 @@ project(Graaf
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-set(${GRAAF_LIB_TARGET_NAME} ${PROJECT_NAME})
+# The target name of the Library, what name you give to the Interface
+set(GRAAF_LIB_TARGET_NAME ${PROJECT_NAME})
 
 # Example usages of the library
 option(SKIP_EXAMPLES "Skip building the examples" OFF)
@@ -31,7 +32,8 @@ if(NOT SKIP_BENCHMARKS)
 add_subdirectory(perf)
 endif()
 
-add_library(Graaf INTERFACE)
-#add_library(${PROJECT_NAME}::${GRAAF_LIB_TARGET_NAME} ALIAS ${PROJECT_NAME})
+#Adding Interface to enable use of FetchContent
+add_library(${GRAAF_LIB_TARGET_NAME} INTERFACE)
+add_library(${PROJECT_NAME}::${GRAAF_LIB_TARGET_NAME} ALIAS ${PROJECT_NAME})
 
-target_include_directories(Graaf INTERFACE "${PROJECT_BINARY_DIR}" "${PROJECT_SOURCE_DIR}/include/")
+target_include_directories(${GRAAF_LIB_TARGET_NAME} INTERFACE "${PROJECT_BINARY_DIR}" "${PROJECT_SOURCE_DIR}/include/")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,8 @@ project(Graaf
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+set(${GRAAF_LIB_TARGET_NAME} ${PROJECT_NAME})
+
 # Example usages of the library
 option(SKIP_EXAMPLES "Skip building the examples" OFF)
 if(NOT SKIP_EXAMPLES)
@@ -29,3 +31,7 @@ if(NOT SKIP_BENCHMARKS)
 add_subdirectory(perf)
 endif()
 
+add_library(Graaf INTERFACE)
+#add_library(${PROJECT_NAME}::${GRAAF_LIB_TARGET_NAME} ALIAS ${PROJECT_NAME})
+
+target_include_directories(Graaf INTERFACE "${PROJECT_BINARY_DIR}" "${PROJECT_SOURCE_DIR}/include/")

--- a/include/graaflib/algorithm/strongly_connected_components/tarjan.h
+++ b/include/graaflib/algorithm/strongly_connected_components/tarjan.h
@@ -3,7 +3,6 @@
 #include <graaflib/algorithm/strongly_connected_components/common.h>
 #include <graaflib/graph.h>
 #include <graaflib/types.h>
-#include <algorithm>
 
 namespace graaf::algorithm {
 

--- a/include/graaflib/algorithm/strongly_connected_components/tarjan.h
+++ b/include/graaflib/algorithm/strongly_connected_components/tarjan.h
@@ -3,6 +3,7 @@
 #include <graaflib/algorithm/strongly_connected_components/common.h>
 #include <graaflib/graph.h>
 #include <graaflib/types.h>
+#include <algorithm>
 
 namespace graaf::algorithm {
 


### PR DESCRIPTION
I tried to use FetchContent for CMake to install graaflib but it didn't work, after some testing I decided to create a fork.

I made a new interface with add_library and added the include directory over target_include_directories, when using FetchContent with these modifications, including graaflib worked.

I also made sure I could build and test the project so that this didn't break stuff, and I got a build error telling me that the tarjan test used std::sort as an unknown target, I added an include for <algorithm> in tarjan.h to make the project build and the tests ran at 100%

I'm not really acquainted with how you properly write CMakeList files so if there are any issues feel free to tell me.