### PR TITLE
[CI] Re-add clang to matrix build

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        compiler: [g++]
+        compiler: [g++, clang++]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Reverts #169. The root cause in the respective runner has been fixed recently (https://github.com/actions/runner-images/issues/9679).