### PR TITLE
fix: Potential race for file access in DotTest

### DIFF
--- a/test/graaflib/io/dot_test.cpp
+++ b/test/graaflib/io/dot_test.cpp
@@ -74,7 +74,7 @@ inline std::pair<vertex_id_t, vertex_id_t> make_sorted_pair(
 
 TEST(DotTest, EmptyUndirectedGraph) {
   // GIVEN
-  const std::filesystem::path path{"./test.dot"};
+  const std::filesystem::path path{"./DotTest_EmptyUndirectedGraph.dot"};
   undirected_graph<int, int> graph{};
 
   // WHEN
@@ -87,7 +87,7 @@ TEST(DotTest, EmptyUndirectedGraph) {
 
 TEST(DotTest, EmptyDirectedGraph) {
   // GIVEN
-  const std::filesystem::path path{"./test.dot"};
+  const std::filesystem::path path{"./DotTest_EmptyDirectedGraph.dot"};
   directed_graph<int, int> graph{};
 
   // WHEN
@@ -100,7 +100,7 @@ TEST(DotTest, EmptyDirectedGraph) {
 
 TEST(DotTest, UndirectedGraph) {
   // GIVEN
-  const std::filesystem::path path{"./test.dot"};
+  const std::filesystem::path path{"./DotTest_UndirectedGraph.dot"};
   undirected_graph<int, int> graph{};
 
   const auto vertex_1{graph.add_vertex(10)};
@@ -144,7 +144,7 @@ TEST(DotTest, UndirectedGraph) {
 
 TEST(DotTest, DirectedGraph) {
   // GIVEN
-  const std::filesystem::path path{"./test.dot"};
+  const std::filesystem::path path{"./DotTest_DirectedGraph.dot"};
   directed_graph<int, int> graph{};
 
   const auto vertex_1{graph.add_vertex(10)};
@@ -198,7 +198,8 @@ TEST(DotTest, UserProvidedVertexAndEdgeClass) {
     std::string string_data{};
   };
 
-  const std::filesystem::path path{"./test.dot"};
+  const std::filesystem::path path{
+      "./DotTest_UserProvidedVertexAndEdgeClass.dot"};
   directed_graph<vertex_t, edge_t> graph{};
 
   const auto vertex_1{graph.add_vertex(vertex_t{10, "vertex 1"})};
@@ -228,7 +229,7 @@ TEST(DotTest, UserProvidedVertexAndEdgeClass) {
 
 TEST(DotTest, DefaultWriters) {
   // GIVEN
-  const std::filesystem::path path{"./test.dot"};
+  const std::filesystem::path path{"./DotTest_DefaultWriters.dot"};
   directed_graph<int, float> graph{};
 
   const auto vertex_1{graph.add_vertex(10)};

--- a/test/graaflib/io/dot_test.cpp
+++ b/test/graaflib/io/dot_test.cpp
@@ -74,7 +74,8 @@ inline std::pair<vertex_id_t, vertex_id_t> make_sorted_pair(
 
 TEST(DotTest, EmptyUndirectedGraph) {
   // GIVEN
-  const std::filesystem::path path{"./DotTest_EmptyUndirectedGraph.dot"};
+  const std::filesystem::path path{std::filesystem::temp_directory_path() /
+                                   "DotTest_EmptyUndirectedGraph.dot"};
   undirected_graph<int, int> graph{};
 
   // WHEN
@@ -87,7 +88,8 @@ TEST(DotTest, EmptyUndirectedGraph) {
 
 TEST(DotTest, EmptyDirectedGraph) {
   // GIVEN
-  const std::filesystem::path path{"./DotTest_EmptyDirectedGraph.dot"};
+  const std::filesystem::path path{std::filesystem::temp_directory_path() /
+                                   "DotTest_EmptyDirectedGraph.dot"};
   directed_graph<int, int> graph{};
 
   // WHEN
@@ -100,7 +102,8 @@ TEST(DotTest, EmptyDirectedGraph) {
 
 TEST(DotTest, UndirectedGraph) {
   // GIVEN
-  const std::filesystem::path path{"./DotTest_UndirectedGraph.dot"};
+  const std::filesystem::path path{std::filesystem::temp_directory_path() /
+                                   "DotTest_UndirectedGraph.dot"};
   undirected_graph<int, int> graph{};
 
   const auto vertex_1{graph.add_vertex(10)};
@@ -144,7 +147,8 @@ TEST(DotTest, UndirectedGraph) {
 
 TEST(DotTest, DirectedGraph) {
   // GIVEN
-  const std::filesystem::path path{"./DotTest_DirectedGraph.dot"};
+  const std::filesystem::path path{std::filesystem::temp_directory_path() /
+                                   "DotTest_DirectedGraph.dot"};
   directed_graph<int, int> graph{};
 
   const auto vertex_1{graph.add_vertex(10)};
@@ -199,7 +203,8 @@ TEST(DotTest, UserProvidedVertexAndEdgeClass) {
   };
 
   const std::filesystem::path path{
-      "./DotTest_UserProvidedVertexAndEdgeClass.dot"};
+      std::filesystem::temp_directory_path() /
+      "DotTest_UserProvidedVertexAndEdgeClass.dot"};
   directed_graph<vertex_t, edge_t> graph{};
 
   const auto vertex_1{graph.add_vertex(vertex_t{10, "vertex 1"})};
@@ -229,7 +234,8 @@ TEST(DotTest, UserProvidedVertexAndEdgeClass) {
 
 TEST(DotTest, DefaultWriters) {
   // GIVEN
-  const std::filesystem::path path{"./DotTest_DefaultWriters.dot"};
+  const std::filesystem::path path{std::filesystem::temp_directory_path() /
+                                   "DotTest_DefaultWriters.dot"};
   directed_graph<int, float> graph{};
 
   const auto vertex_1{graph.add_vertex(10)};


### PR DESCRIPTION
It appears like CI runs for `DotTest` fail non-deterministically. See recent runs of the coverage CI:

- [PR-245](https://github.com/bobluppes/graaf/actions/runs/11777353577/job/32801585412?pr=245)
- [PR-246](https://github.com/bobluppes/graaf/actions/runs/11899516112/job/33158300868?pr=246)
- [PR-247](https://github.com/bobluppes/graaf/actions/runs/11891803869/job/33133311432?pr=247)

While I can't reproduce this locally, my suspicion is that multiple tests use `"./test.dot"` simultaneously, which then causes race conditions or file access conflicts due to concurrent write/read attempts to the same file path.
This PR provides a fix by making the filenames unique (683ed984ad624dad0d87bbf8741fcc4a63a7bfdf).
f826ab66d8ea36e7c7702a4447db9a1622c54b89 increases cross-platform compatibility and should be unrelated to this issue.