### PR TITLE
Fix coverage workflows

### DIFF
--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -19,7 +19,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Install dependencies
-      run: sudo apt-get install lcov -y
+      run: sudo apt-get install g++ lcov -y
 
     - name: Pull CMake modules
       uses: actions/checkout@v4

--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -13,7 +13,7 @@ jobs:
     # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.
     # You can convert this to a matrix build if you need cross-platform coverage.
     # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -19,7 +19,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Install dependencies
-      run: sudo apt-get install g++ lcov -y
+      run: sudo apt-get install lcov -y
 
     - name: Pull CMake modules
       uses: actions/checkout@v4

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -34,7 +34,7 @@ jobs:
     # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.
     # You can convert this to a matrix build if you need cross-platform coverage.
     # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -40,7 +40,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Install dependencies
-      run: sudo apt-get install lcov -y
+      run: sudo apt-get install g++ lcov -y
 
     - name: Pull CMake modules
       uses: actions/checkout@v4

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -40,7 +40,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Install dependencies
-      run: sudo apt-get install g++ lcov -y
+      run: sudo apt-get install lcov -y
 
     - name: Pull CMake modules
       uses: actions/checkout@v4


### PR DESCRIPTION
The coverage workflow was broken on ubuntu 24.04 machines. For now pinning the workflow to 22.04.