### PR TITLE
Add get_predecessors to Graph API

### DIFF
--- a/include/graaflib/graph.h
+++ b/include/graaflib/graph.h
@@ -172,6 +172,14 @@ class graph {
   [[nodiscard]] vertices_t get_neighbors(vertex_id_t vertex_id) const;
 
   /**
+   * Get a list of predecessor vertices (vertices pointing to this vertex)
+   *
+   * @param  vertex_id The ID of the vertex
+   * @return vertices_t - A list of predecessor vertices
+   */
+  [[nodiscard]] vertices_t get_predecessors(vertex_id_t vertex_id) const;
+
+  /**
    * Add a vertex to the graph
    *
    * @param  vertex The vertex to be added

--- a/include/graaflib/graph.tpp
+++ b/include/graaflib/graph.tpp
@@ -129,6 +129,25 @@ graph<VERTEX_T, EDGE_T, GRAPH_TYPE_V>::get_neighbors(
 }
 
 template <typename VERTEX_T, typename EDGE_T, graph_type GRAPH_TYPE_V>
+typename graph<VERTEX_T, EDGE_T, GRAPH_TYPE_V>::vertices_t
+graph<VERTEX_T, EDGE_T, GRAPH_TYPE_V>::get_predecessors(
+    vertex_id_t vertex_id) const {
+
+  using enum graph_type;
+  if constexpr (GRAPH_TYPE_V == UNDIRECTED) {
+    return get_neighbors(vertex_id);
+  }
+  vertices_t predecessors{};
+  for (const auto& [source_id, neighbors] : adjacency_list_) {
+    if (neighbors.contains(vertex_id)) {
+      predecessors.insert(source_id);
+    }
+  }
+
+  return predecessors;
+}
+
+template <typename VERTEX_T, typename EDGE_T, graph_type GRAPH_TYPE_V>
 vertex_id_t graph<VERTEX_T, EDGE_T, GRAPH_TYPE_V>::add_vertex(auto&& vertex) {
   while (has_vertex(vertex_id_supplier_)) {
     ++vertex_id_supplier_;


### PR DESCRIPTION
This PR adds get_predecessors as the inverse of get_neighbors to retrieve all vertices pointing to a given ID. In undirected graphs, it simply redirects to get_neighbors to maintain symmetry, while in directed graphs, it scans the adjacency list for incoming edges. This provides a complete API for bidirectional graph traversal without requiring a second adjacency list.
