### PR TITLE
docs: fix broken Bron-Kerbosch link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ take a look at the [docs](https://bobluppes.github.io/graaf/docs/algorithms/intr
    - [Breadth-First Search (BFS)](https://bobluppes.github.io/graaf/docs/algorithms/traversal/breadth-first-search)
    - [Depth-First Search (DFS)](https://bobluppes.github.io/graaf/docs/algorithms/traversal/depth-first-search)
 8. [**Clique Detection**](https://bobluppes.github.io/graaf/docs/category/clique-detection)
-    - [Bron-Kerbosch](https://bobluppes.github.io/graaf/docs/algorithms/clique-detection/bron-kerbosch)
+    - [Bron-Kerbosch](https://bobluppes.github.io/graaf/docs/algorithms/clique-detection/bron_kerbosch)
 
 # Contributing
 


### PR DESCRIPTION
Closes #307.

The algorithms list in `README.md` linked to `.../clique-detection/bron-kerbosch` (dash), but the actual docs page uses an underscore: `.../clique-detection/bron_kerbosch`.

Verified:
- `https://bobluppes.github.io/graaf/docs/algorithms/clique-detection/bron-kerbosch` → **404**
- `https://bobluppes.github.io/graaf/docs/algorithms/clique-detection/bron_kerbosch` → **200**