### PR TITLE
Fix external dependency build in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,7 @@ install(
     DIRECTORY "${PROJECT_SOURCE_DIR}/include/"
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )
-configure_file(${CMAKE_SOURCE_DIR}/packaging/graaf.pc.in graaf.pc @ONLY)
+configure_file(${PROJECT_SOURCE_DIR}/packaging/graaf.pc.in graaf.pc @ONLY)
 install(
     FILES ${CMAKE_CURRENT_BINARY_DIR}/graaf.pc
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig


### PR DESCRIPTION
Fixes bug introduced in 2a4715f

This fix allows Graaf to be used as an external dependency using CMake's `FetchContent_Declare`. With `CMAKE_SOURCE_DIR`, CMake will look for `packaging/graaf.pc` in the project using Graaf, rather than Graaf itself. `PROJECT_SOURCE_DIR` is used over
`CMAKE_CURRENT_SOURCE_DIR` to maintain consistency within the `CMakeLists.txt`.