### PR TITLE
Fix FetchContent following 2a4715ff46a25048e06078ea20afc325d59f987a

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,8 +43,10 @@ install(
     DIRECTORY "${PROJECT_SOURCE_DIR}/include/"
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )
-configure_file(${CMAKE_SOURCE_DIR}/packaging/graaf.pc.in graaf.pc @ONLY)
-install(
-    FILES ${CMAKE_CURRENT_BINARY_DIR}/graaf.pc
-    DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
-)
+if(CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)  # Only if graalib is the top-level project (e.g. skip if obtained via FetchContent)
+    configure_file(${CMAKE_SOURCE_DIR}/packaging/graaf.pc.in graaf.pc @ONLY)
+    install(
+        FILES ${CMAKE_CURRENT_BINARY_DIR}/graaf.pc
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
+    )
+endif()


### PR DESCRIPTION
Fix FetchContent by only installing pkg-config files when graaflib is the top project.

Closes #310 