### PR TITLE
docs: fix Bron-Kerbosch link

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ take a look at the [docs](https://bobluppes.github.io/graaf/docs/algorithms/intr
    - [Breadth-First Search (BFS)](https://bobluppes.github.io/graaf/docs/algorithms/traversal/breadth-first-search)
    - [Depth-First Search (DFS)](https://bobluppes.github.io/graaf/docs/algorithms/traversal/depth-first-search)
 8. [**Clique Detection**](https://bobluppes.github.io/graaf/docs/category/clique-detection)
-    - [Bron-Kerbosch](https://bobluppes.github.io/graaf/docs/algorithms/clique-detection/bron-kerbosch)
+    - [Bron-Kerbosch](https://bobluppes.github.io/graaf/docs/algorithms/clique-detection/bron_kerbosch)
 
 # Contributing
 


### PR DESCRIPTION
## Summary
- Fixes the README link to the Bron-Kerbosch documentation by using the documented `bron_kerbosch` path.

Fixes #307.

## Validation
- Verified the README contains the corrected URL.
