### PR TITLE
docs: fix Bron-Kerbosch link

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ take a look at the [docs](https://bobluppes.github.io/graaf/docs/algorithms/intr
    - [Breadth-First Search (BFS)](https://bobluppes.github.io/graaf/docs/algorithms/traversal/breadth-first-search)
    - [Depth-First Search (DFS)](https://bobluppes.github.io/graaf/docs/algorithms/traversal/depth-first-search)
 8. [**Clique Detection**](https://bobluppes.github.io/graaf/docs/category/clique-detection)
-    - [Bron-Kerbosch](https://bobluppes.github.io/graaf/docs/algorithms/clique-detection/bron-kerbosch)
+    - [Bron-Kerbosch](https://bobluppes.github.io/graaf/docs/algorithms/clique-detection/bron_kerbosch)
 
 # Contributing
 


### PR DESCRIPTION
﻿## Why

The README links to the Bron-Kerbosch documentation using `bron-kerbosch`, but the published docs path uses `bron_kerbosch`. The old link returns 404.

Fixes #307.

## What Changed

Updated the README link to point at the existing Bron-Kerbosch documentation page.

## Verification

- `curl.exe -I -L https://bobluppes.github.io/graaf/docs/algorithms/clique-detection/bron-kerbosch` returned `404 Not Found`.
- `curl.exe -I -L https://bobluppes.github.io/graaf/docs/algorithms/clique-detection/bron_kerbosch` returned `200 OK`.
