### PR TITLE
fix: use snake_case inputs for actions/first-interaction@v3

### DIFF
--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -11,6 +11,6 @@ jobs:
     steps:
     - uses: actions/first-interaction@v3
       with:
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
-        issue-message: "Hi there! Thank you for creating your first issue on the Graaf library, we will look into it shortly. In the mean time, please make sure the issue has the correct labels set."
-        pr-message: "Hi there! Thank you for creating your first pull-request on the Graaf library :)"
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        issue_message: "Hi there! Thank you for creating your first issue on the Graaf library, we will look into it shortly. In the mean time, please make sure the issue has the correct labels set."
+        pr_message: "Hi there! Thank you for creating your first pull-request on the Graaf library :)"


### PR DESCRIPTION
## Why

#292 bumped \`actions/first-interaction\` from v1 to v3, but v3 renamed its inputs from kebab-case to snake_case (\`repo-token\` -> \`repo_token\`, \`issue-message\` -> \`issue_message\`, \`pr-message\` -> \`pr_message\`). The old kebab-case names are silently ignored (with an "Unexpected input(s)" warning), leaving the required \`issue_message\` unset. This crashes the Greetings workflow on any genuine \`opened\` pull_request_target/issues event.

Synchronize events (e.g. pushes to an existing PR branch) happen to skip past the crash, since the action checks the event action before validating required inputs — which is why this went unnoticed until a fresh PR/issue is actually opened.

## What Changed

Renamed the three inputs to their v3 snake_case equivalents.

## Verification

Confirmed the crash in CI logs on a real "opened" event (dependabot PR #345's initial run), and confirmed the same input-name mismatch by diffing against v3's schema.