### PR TITLE
build: use PROJECT_IS_TOP_LEVEL for the pkgconfig top-level guard

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,16 @@ project(Graaf
   LANGUAGES C CXX
 )
 
+# CMake >=3.21 sets this automatically; fall back to the equivalent check
+# since this project's floor is CMake 3.11.
+if(NOT DEFINED PROJECT_IS_TOP_LEVEL)
+  if(CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)
+    set(PROJECT_IS_TOP_LEVEL TRUE)
+  else()
+    set(PROJECT_IS_TOP_LEVEL FALSE)
+  endif()
+endif()
+
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 # This project uses C++ 20 features
@@ -43,7 +53,7 @@ install(
     DIRECTORY "${PROJECT_SOURCE_DIR}/include/"
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )
-if(CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)  # Only if graalib is the top-level project (e.g. skip if obtained via FetchContent)
+if(PROJECT_IS_TOP_LEVEL)  # Skip if Graaf was obtained via FetchContent
     configure_file(${CMAKE_SOURCE_DIR}/packaging/graaf.pc.in graaf.pc @ONLY)
     install(
         FILES ${CMAKE_CURRENT_BINARY_DIR}/graaf.pc


### PR DESCRIPTION
## Why

#312 fixed the FetchContent crash from #310 by skipping the pkgconfig install block unless Graaf is the top-level project, via `CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR`. CMake 3.21+ exposes exactly this as the built-in `PROJECT_IS_TOP_LEVEL` variable, which is clearer and self-documenting -- but this project's floor is CMake 3.11, so it isn't guaranteed to be defined.

## What Changed

Defines `PROJECT_IS_TOP_LEVEL` ourselves (matching CMake's own semantics) when it isn't already set by CMake, and uses it for the pkgconfig guard instead of the raw path comparison. No behavior change; same guard, clearer name, and reusable if more top-level-only logic gets added later.

## Verification

Built and installed locally in both scenarios:
- As the top-level project: `graaf.pc` is still generated and installed.
- As a FetchContent dependency of a throwaway consumer project: no `.pc` file is generated (matching #312's intended behavior), headers still install correctly.