### PR TITLE
ci: bump Node.js to 20 for documentation builds

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v7
         with:
-          node-version: "18"
+          node-version: "20"
 
       - name: Build Docusaurus website
         run: |

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -86,7 +86,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v7
         with:
-          node-version: "18"
+          node-version: "20"
 
       - name: Build Docusaurus website
         run: |


### PR DESCRIPTION
## Summary
- Pending dependabot PRs bump Docusaurus to 3.10.2, which requires Node.js >=20
- `verify_documentation` (pull-request.yml) and `Documentation` (documentation.yml) were pinned to Node 18, so those docs builds fail once Docusaurus is bumped
- Bump both workflows to Node 20 so the docs build stays green after the dependabot Docusaurus upgrades merge

## Test plan
- [ ] CI passes on this PR
- [ ] Follow-up: re-run CI on the pending Docusaurus dependabot PRs (#354, #355) and confirm `verify_documentation` now passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)