### PR TITLE
docs: fix various typos across codebase

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,7 @@ install(
     DIRECTORY "${PROJECT_SOURCE_DIR}/include/"
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )
-if(CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)  # Only if graalib is the top-level project (e.g. skip if obtained via FetchContent)
+if(CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)  # Only if graaflib is the top-level project (e.g. skip if obtained via FetchContent)
     configure_file(${CMAKE_SOURCE_DIR}/packaging/graaf.pc.in graaf.pc @ONLY)
     install(
         FILES ${CMAKE_CURRENT_BINARY_DIR}/graaf.pc

--- a/docs/docs/algorithms/cycle-detection/dfs-based.md
+++ b/docs/docs/algorithms/cycle-detection/dfs-based.md
@@ -46,7 +46,7 @@ template <typename V, typename E>
 
 ```
 
-Cycle detection for unidrected graph.
+Cycle detection for undirected graph.
 
 ```cpp
 template <typename V, typename E>

--- a/docs/docs/examples/example-basics/dot-serialization.md
+++ b/docs/docs/examples/example-basics/dot-serialization.md
@@ -1,6 +1,6 @@
 # Dot Serialization Example
 
-The `to_dot` function as defined under `graaf::io` can be used to searialize graphs to
+The `to_dot` function as defined under `graaf::io` can be used to serialize graphs to
 the [dot format](https://graphviz.org/doc/info/lang.html). This can be handy for debugging purposes, as well as for
 post-processing of your graphs in another tool which supports the format.
 

--- a/docs/docs/examples/example-basics/transport-example.md
+++ b/docs/docs/examples/example-basics/transport-example.md
@@ -32,7 +32,7 @@ struct railroad : public graaf::weighted_edge<double> {
 };
 ```
 
-# Initializing graph, start and end vertecies
+# Initializing graph, start and end vertices
 
 First, we create data structure and initializing graph with vertices and edges
 
@@ -121,7 +121,7 @@ The last one is traversing the graph from a given vertex and printing the result
   const auto unweighted_shortest_path{
       graaf::algorithm::bfs_shortest_path(graph, start, target)};
   print_shortest_path(graph, unweighted_shortest_path,
-                      "example_unwieghted_graph.dot");
+                      "example_unweighted_graph.dot");
 
   seen_edges_t seen_edges{};
   graaf::algorithm::breadth_first_traverse(

--- a/examples/transport/main.cpp
+++ b/examples/transport/main.cpp
@@ -180,7 +180,7 @@ int main() {
   const auto unweighted_shortest_path{
       graaf::algorithm::bfs_shortest_path(graph, start, target)};
   print_shortest_path(graph, unweighted_shortest_path,
-                      "example_unwieghted_graph.dot");
+                      "example_unweighted_graph.dot");
 
   seen_edges_t seen_edges{};
   graaf::algorithm::breadth_first_traverse(graph, start,

--- a/include/graaflib/algorithm/shortest_path/a_star.tpp
+++ b/include/graaflib/algorithm/shortest_path/a_star.tpp
@@ -84,7 +84,7 @@ std::optional<graph_path<WEIGHT_T>> a_star_search(
         // always update vertex_info[neighbor]
         vertex_info[neighbor] = {
             neighbor,   // vertex id
-            f_score,    // f_score = tentantive_g_score + h(neighbor)
+            f_score,    // f_score = tentative_g_score + h(neighbor)
             current.id  // neighbor vertex came from current vertex
         };
 

--- a/include/graaflib/graph.h
+++ b/include/graaflib/graph.h
@@ -55,7 +55,7 @@ class graph {
   [[nodiscard]] std::size_t edge_count() const noexcept;
 
   /**
-   * @brief Get the intrnal vertices
+   * @brief Get the internal vertices
    *
    * @return const vertex_id_to_vertex_t& Map from vertex id to the user
    * provided vertex.

--- a/test/graaflib/io/dot_test.cpp
+++ b/test/graaflib/io/dot_test.cpp
@@ -39,7 +39,7 @@ const auto make_edge_string{[](edge_id_t edge_id,
 }};
 
 /**
- * @brief Returns a pair with the smalles vertex_id first.
+ * @brief Returns a pair with the smallest vertex_id first.
  * Edges from undirected graphs are sorted on vertex ID, this function is used
  * to sort the expected values in the same fashion.
  *

--- a/test/utils/scenarios/scenarios.h
+++ b/test/utils/scenarios/scenarios.h
@@ -140,7 +140,7 @@ template <typename GRAPH_T>
 
 /**
  * Creates a scenario containing a disconnected graph consisting of two
- * conntected subgraphs. In the visualization below, vertices and edge values
+ * connected subgraphs. In the visualization below, vertices and edge values
  * are shown. Vertex IDs are given between parentheses.
  *
  * The direction of the edges is visualized. However, undirected edges are


### PR DESCRIPTION
## Summary
- Reviewed the codebase (README/docs, doc site, comments, CI/build configs) for spelling mistakes using `aspell`
- Fixed 9 typos in comments, documentation, and one generated output filename:
  - `intrnal` → `internal` (`include/graaflib/graph.h`)
  - `searialize` → `serialize` (`docs/docs/examples/example-basics/dot-serialization.md`)
  - `vertecies` → `vertices` (`docs/docs/examples/example-basics/transport-example.md`)
  - `unidrected` → `undirected` (`docs/docs/algorithms/cycle-detection/dfs-based.md`)
  - `unwieghted` → `unweighted` (output filename, updated consistently in `examples/transport/main.cpp` and the matching doc)
  - `conntected` → `connected` (`test/utils/scenarios/scenarios.h`)
  - `smalles` → `smallest` (`test/graaflib/io/dot_test.cpp`)
  - `tentantive` → `tentative` (`include/graaflib/algorithm/shortest_path/a_star.tpp`)
  - `graalib` → `graaflib` (`CMakeLists.txt` comment)

No functional/API changes — comments, docs, and one internally-consistent generated filename only.

## Test plan
- [x] Verified diff only touches comments/docs/strings, no code logic
- [x] Confirmed the renamed `.dot` output filename is updated consistently in both the example source and corresponding doc page