### PR TITLE
feat: add pr-ci-status skill for polling PR CI checks

### DIFF
--- a/.claude/skills/pr-ci-status/SKILL.md
+++ b/.claude/skills/pr-ci-status/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: pr-ci-status
+description: This skill should be used when the user asks to "check PR CI status", "wait for CI to pass", "wait for checks to finish", "poll PR checks", "is CI green yet", or when an agent itself needs to block until a pull request's GitHub Actions checks complete before continuing (e.g. before merging, before reporting a task done). Use it instead of manually re-running `gh pr checks` in a sleep loop.
+---
+
+# PR CI Status
+
+Wait for a pull request's CI checks to finish without burning tokens on
+repeated polling turns.
+
+## Why this exists
+
+The naive way an agent waits for CI is a loop: call `gh pr checks`, see
+pending checks, sleep, call it again, repeat — each iteration costs a full
+turn. This skill instead delegates the entire wait to a single deterministic
+script invocation. The polling loop runs inside the `gh` CLI process itself
+(via `gh pr checks --watch`), so the agent blocks on one tool call and only
+resumes once the checks have actually finished.
+
+## Usage
+
+Run the bundled script instead of calling `gh pr checks` directly:
+
+```bash
+.claude/skills/pr-ci-status/scripts/wait-for-pr-checks.sh [PR] [-R owner/repo] [-i seconds] [-t seconds]
+```
+
+- `PR` — PR number, URL, or branch name. Omit it to use the PR associated
+  with the current branch.
+- `-R, --repo` — target a repo other than the current one.
+- `-i, --interval` — poll interval in seconds, default `60` (i.e. check
+  once a minute, matching how often CI status realistically changes).
+- `-t, --timeout` — give up after this many seconds, default `3600`. Pick a
+  shorter timeout for fast test suites, a longer one for slow pipelines.
+
+The script exits when all checks complete (or the timeout is hit) and
+prints the final check table. Exit codes:
+
+| Code | Meaning |
+| --- | --- |
+| 0 | All checks passed |
+| 1 | One or more checks failed |
+| 124 | Timed out before checks finished |
+| 127 | `gh` CLI is not installed |
+
+## Workflow
+
+1. Open or identify the PR whose checks need to be watched.
+2. Invoke the script with an appropriate `--timeout` for the pipeline being
+   watched (err on the side of a generous timeout — the script returns as
+   soon as checks finish, it does not wait the full timeout on success).
+3. Read the exit code and final check table from the single tool result to
+   decide the next step (merge, fix failing checks, investigate a timeout).
+4. Do not fall back to manually polling `gh pr checks` in a loop — if the
+   script times out, either re-invoke it with a longer `--timeout` or
+   investigate why checks are stuck, rather than polling turn-by-turn.

--- a/.claude/skills/pr-ci-status/scripts/wait-for-pr-checks.sh
+++ b/.claude/skills/pr-ci-status/scripts/wait-for-pr-checks.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Blocks until a pull request's CI checks finish, polling at a fixed interval.
+#
+# This wraps `gh pr checks --watch`, which does its own polling loop inside
+# the `gh` process. Running it as a single tool call lets the caller block on
+# one deterministic command instead of repeatedly invoking `gh pr checks`
+# (or sleeping and re-checking) itself, which burns tokens on every poll.
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: wait-for-pr-checks.sh [PR] [-R owner/repo] [-i seconds] [-t seconds]
+
+Blocks until all CI checks on a pull request finish, polling at a fixed
+interval, then prints the final check table and exits with gh's status
+code.
+
+Arguments:
+  PR              PR number, URL, or branch (default: current branch's PR)
+
+Options:
+  -R, --repo      owner/repo to check (passed through to gh)
+  -i, --interval  Poll interval in seconds (default: 60)
+  -t, --timeout   Give up after this many seconds (default: 3600)
+  -h, --help      Show this help
+
+Exit codes:
+  0    all checks passed
+  8    some checks are still pending (only possible without --watch; not
+       expected here since this script always watches to completion)
+  1    one or more checks failed
+  124  timed out waiting for checks to finish
+  127  the gh CLI is not installed
+EOF
+}
+
+interval=60
+timeout_sec=3600
+repo=()
+pr=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -R|--repo)
+      repo=(-R "$2")
+      shift 2
+      ;;
+    -i|--interval)
+      interval="$2"
+      shift 2
+      ;;
+    -t|--timeout)
+      timeout_sec="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      pr=("$1")
+      shift
+      ;;
+  esac
+done
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "error: gh CLI is not installed or not on PATH" >&2
+  exit 127
+fi
+
+echo "Polling CI checks every ${interval}s (timeout ${timeout_sec}s)..." >&2
+
+set +e
+timeout "$timeout_sec" gh pr checks "${pr[@]}" "${repo[@]}" --watch --interval "$interval"
+status=$?
+set -e
+
+if [[ $status -eq 124 ]]; then
+  echo "RESULT: timed out after ${timeout_sec}s — checks did not finish in time" >&2
+fi
+
+exit "$status"


### PR DESCRIPTION
## Summary
- Adds a Claude Code skill (`.claude/skills/pr-ci-status`) that wraps `gh pr checks --watch` in a deterministic script, letting an agent block on a single tool call while CI runs instead of spending a turn re-checking status every minute.
- Script (`scripts/wait-for-pr-checks.sh`) supports specifying the PR, target repo, poll interval (default 60s), and an overall timeout, and exits with a status code reflecting pass/fail/timeout.

## Test plan
- [x] `bash -n` on the script to check syntax
- [x] Ran the script against PR #362 (`-t 20`) in this repo and confirmed it correctly reports the passed checks and exits 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)