### PR TITLE
feat: add dependabot-merge-train skill for sequential dependency PR merges

### DIFF
--- a/.claude/skills/dependabot-merge-train/SKILL.md
+++ b/.claude/skills/dependabot-merge-train/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: dependabot-merge-train
+description: This skill should be used when the user asks to "merge the dependabot PRs", "clear the dependabot backlog", "process dependency PRs", "merge dependabot PRs one by one", or "run a dependabot merge train". Sequentially rebases, reviews, waits on CI for, and merges open dependabot pull requests one at a time so that combinations of dependency bumps never land untested together.
+---
+
+# Dependabot Merge Train
+
+Merge every open dependabot pull request into the base branch one at a
+time, each rebased onto the latest base branch and CI-verified in
+isolation, so no untested combination of dependency bumps ever lands
+together.
+
+## Why one at a time
+
+Two dependabot PRs can each pass CI individually against the current base
+branch and still break the build once both are merged, because neither was
+ever tested against the other's changes. Rebasing and re-running CI for
+each PR immediately before merging it — using the base branch as it exists
+*after* the previous PR merged — guarantees every merge commit was
+actually validated before it landed, not just its source branch in
+isolation.
+
+## Workflow
+
+Repeat this loop until no open dependabot PRs remain:
+
+1. **List remaining PRs.**
+
+   ```bash
+   .claude/skills/dependabot-merge-train/scripts/list-dependabot-prs.sh [-R owner/repo]
+   ```
+
+   Pick the next one to process — default to the lowest PR number unless a
+   later one is blocked on an earlier one's outcome.
+
+2. **Bring it up to date with the base branch.** Check
+   `gh pr view <PR> --json mergeStateStatus` first. If it is already
+   `CLEAN`/`BEHIND`-free relative to the latest base branch (e.g. this is
+   the first PR processed and nothing else has merged yet), skip straight
+   to review. Otherwise request a rebase and block until dependabot
+   delivers it:
+
+   ```bash
+   .claude/skills/dependabot-merge-train/scripts/rebase-and-wait.sh <PR> [-R owner/repo] [-i seconds] [-t seconds]
+   ```
+
+   This posts `@dependabot rebase` as a PR comment and polls the PR's head
+   commit once a minute (configurable) until dependabot pushes the rebase,
+   instead of the agent re-checking the PR on every turn. If dependabot
+   closes the PR instead of rebasing (it does this when the update is no
+   longer needed, e.g. a transitive bump that another merge already
+   satisfied), treat it as resolved and move to the next PR.
+
+3. **Review the diff.** Run `gh pr view <PR>` and `gh pr diff <PR>` and
+   confirm:
+   - The change is confined to manifest/lockfile files (or whatever
+     dependabot normally touches in this repo) with no unrelated edits.
+   - The version bump direction and release notes in the PR body look
+     sane (no major-version jump hiding a breaking change unless that's
+     genuinely intended).
+   - There isn't an open compatibility concern called out in the PR body
+     (dependabot surfaces compatibility scores/release notes there).
+
+   If anything looks off, stop and flag it instead of proceeding — don't
+   merge a PR whose contents haven't actually been read.
+
+4. **Wait for CI**, using the `pr-ci-status` skill rather than polling
+   manually:
+
+   ```bash
+   .claude/skills/pr-ci-status/scripts/wait-for-pr-checks.sh <PR> [-R owner/repo]
+   ```
+
+5. **If CI fails**, diagnose before giving up on the PR:
+   - Pull the failing job logs (`gh run list --branch <headRefName>` then
+     `gh run view <run-id> --log-failed`) to see whether the failure is
+     caused by the dependency bump itself, an unrelated flake, or a
+     preexisting issue on the base branch.
+   - Transient/flaky failures: re-run with `gh run rerun <run-id> --failed`
+     and wait again with the same script.
+   - Genuine breakage caused by the bump: this is exactly the scenario the
+     one-at-a-time process exists to catch. Do not merge. Leave a comment
+     explaining the failure, skip this PR, and continue the train with the
+     remaining ones — a human needs to decide how to resolve it (patch,
+     pin, or close).
+   - Failure unrelated to dependencies (base branch was already broken):
+     fix the root cause first (outside this loop) before continuing the
+     train, since every subsequent PR will inherit the same failure after
+     being rebased.
+
+6. **Merge**, once review and CI both pass:
+
+   ```bash
+   gh pr merge <PR> [-R owner/repo] --squash --delete-branch
+   ```
+
+   Match whatever merge method the repo actually uses if it differs from
+   squash — check a couple of recently merged PRs
+   (`gh pr list --state merged --limit 5`) if unsure.
+
+7. **Continue the loop.** Go back to step 1 — the base branch has moved,
+   so re-list remaining PRs and rebase the next one against the new head
+   before reviewing it.
+
+## Notes
+
+- Never merge a PR with pending or failing required checks. If
+  `wait-for-pr-checks.sh` times out, either re-invoke it with a longer
+  `--timeout` or investigate why checks are stuck — don't fall back to
+  merging without a completed CI run.
+- Process strictly one PR at a time end-to-end (rebase → review → CI →
+  merge) rather than kicking off rebases for several PRs up front; a PR
+  rebased earlier goes stale the moment an earlier one in the train
+  merges.
+- If a PR gets closed or superseded mid-train (dependabot does this when a
+  later bump supersedes an earlier one), just re-list and continue — don't
+  treat it as a failure.

--- a/.claude/skills/dependabot-merge-train/scripts/list-dependabot-prs.sh
+++ b/.claude/skills/dependabot-merge-train/scripts/list-dependabot-prs.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# List open dependabot pull requests, oldest (lowest PR number) first.
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: list-dependabot-prs.sh [-R owner/repo]
+
+Lists open pull requests authored by dependabot, oldest first, printing
+number, merge state, branch, and title as tab-separated columns. Use the
+PR numbers as the processing order for a sequential dependabot merge
+train: rebase, review, wait for CI, merge, then move to the next one.
+
+Options:
+  -R, --repo   owner/repo to query (passed through to gh)
+  -h, --help   Show this help
+EOF
+}
+
+repo=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -R|--repo)
+      repo=(-R "$2")
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "error: gh CLI is not installed or not on PATH" >&2
+  exit 127
+fi
+
+gh pr list --state open --author app/dependabot "${repo[@]}" \
+  --json number,title,headRefName,mergeStateStatus,updatedAt \
+  --jq 'sort_by(.number) | .[] | [(.number|tostring), .mergeStateStatus, .headRefName, .title] | @tsv'

--- a/.claude/skills/dependabot-merge-train/scripts/rebase-and-wait.sh
+++ b/.claude/skills/dependabot-merge-train/scripts/rebase-and-wait.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Ask dependabot to rebase a PR onto the current base branch, then block
+# until it pushes the new commit (or the timeout elapses), polling at a
+# fixed interval instead of re-checking the PR on every agent turn.
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: rebase-and-wait.sh PR [-R owner/repo] [-i seconds] [-t seconds]
+
+Comments "@dependabot rebase" on PR, then polls its head commit until it
+changes, printing the new SHA once the rebase lands.
+
+Arguments:
+  PR              PR number
+
+Options:
+  -R, --repo      owner/repo (passed through to gh)
+  -i, --interval  Poll interval in seconds (default: 60)
+  -t, --timeout   Give up after this many seconds (default: 900)
+  -h, --help      Show this help
+
+Exit codes:
+  0    dependabot pushed a new commit
+  124  timed out waiting for the rebase
+  127  the gh CLI is not installed
+EOF
+}
+
+interval=60
+timeout_sec=900
+repo=()
+pr=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -R|--repo)
+      repo=(-R "$2")
+      shift 2
+      ;;
+    -i|--interval)
+      interval="$2"
+      shift 2
+      ;;
+    -t|--timeout)
+      timeout_sec="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      pr="$1"
+      shift
+      ;;
+  esac
+done
+
+if [[ -z "$pr" ]]; then
+  echo "error: PR number is required" >&2
+  usage
+  exit 2
+fi
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "error: gh CLI is not installed or not on PATH" >&2
+  exit 127
+fi
+
+before_sha=$(gh pr view "$pr" "${repo[@]}" --json headRefOid -q .headRefOid)
+gh pr comment "$pr" "${repo[@]}" --body "@dependabot rebase" >/dev/null
+
+echo "Requested rebase on PR #${pr} (head was ${before_sha}); polling every ${interval}s (timeout ${timeout_sec}s)..." >&2
+
+elapsed=0
+while (( elapsed < timeout_sec )); do
+  sleep "$interval"
+  elapsed=$((elapsed + interval))
+  current_sha=$(gh pr view "$pr" "${repo[@]}" --json headRefOid -q .headRefOid)
+  if [[ "$current_sha" != "$before_sha" ]]; then
+    echo "RESULT: rebased, new head ${current_sha}"
+    exit 0
+  fi
+done
+
+echo "RESULT: timed out after ${timeout_sec}s waiting for dependabot to rebase PR #${pr}" >&2
+exit 124


### PR DESCRIPTION
## Summary
- Adds a Claude Code skill (`.claude/skills/dependabot-merge-train`) that processes open dependabot PRs one at a time: rebase onto the latest base branch, review the diff, wait for CI (via the `pr-ci-status` skill), then merge — before moving to the next PR.
- Goal: prevent combinations of dependency bumps from landing untested together. Each PR is re-validated against the base branch as it exists *after* the previous PR merged, not just tested in isolation against a stale base.
- `scripts/list-dependabot-prs.sh` lists open dependabot PRs, oldest first.
- `scripts/rebase-and-wait.sh` comments `@dependabot rebase` on a PR and polls its head commit once a minute until dependabot pushes the rebase, instead of the agent re-checking every turn.
- The skill documents how to diagnose and handle CI failures (flaky vs. genuine breakage vs. preexisting base-branch issue) before deciding whether to merge or skip a PR.

## Test plan
- [x] `bash -n` on both scripts to check syntax
- [x] Ran `list-dependabot-prs.sh` against this repo and confirmed it correctly lists the open dependabot PR (#362)
- [ ] `rebase-and-wait.sh` not executed against a live PR in this test pass (it posts a real `@dependabot rebase` comment, a mutating action) — reviewed manually instead

🤖 Generated with [Claude Code](https://claude.com/claude-code)