### PR TITLE
fix: add missing standard library includes for gcc 16 / clang 23

### DIFF
--- a/include/graaflib/algorithm/clique_detection/bron_kerbosch.h
+++ b/include/graaflib/algorithm/clique_detection/bron_kerbosch.h
@@ -2,6 +2,8 @@
 
 #include <graaflib/graph.h>
 
+#include <vector>
+
 namespace graaf::algorithm {
 /**
  * @brief Finds all cliques in an undirected graph using the Bron-Kerbosch

--- a/include/graaflib/algorithm/shortest_path/floyd_warshall.h
+++ b/include/graaflib/algorithm/shortest_path/floyd_warshall.h
@@ -3,6 +3,8 @@
 #include <graaflib/graph.h>
 #include <graaflib/types.h>
 
+#include <vector>
+
 namespace graaf::algorithm {
 /**
  * @brief Floyd-Warshall Algorithm

--- a/include/graaflib/algorithm/topological_sorting/dfs_topological_sorting.h
+++ b/include/graaflib/algorithm/topological_sorting/dfs_topological_sorting.h
@@ -3,6 +3,7 @@
 #include <graaflib/graph.h>
 
 #include <optional>
+#include <vector>
 
 namespace graaf::algorithm {
 /**

--- a/include/graaflib/graph.tpp
+++ b/include/graaflib/graph.tpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdlib>
 #include <stdexcept>
 #include <string>
 

--- a/include/graaflib/properties/vertex_properties.tpp
+++ b/include/graaflib/properties/vertex_properties.tpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <algorithm>
+#include <cstdlib>
 
 #include "vertex_properties.h"
 

--- a/test/graaflib/algorithm/shortest_path/floyd_warshall_test.cpp
+++ b/test/graaflib/algorithm/shortest_path/floyd_warshall_test.cpp
@@ -2,6 +2,8 @@
 #include <gtest/gtest.h>
 #include <utils/fixtures/fixtures.h>
 
+#include <climits>
+
 namespace graaf::algorithm {
 
 namespace {


### PR DESCRIPTION
## Summary
- Adds `#include <climits>` to `test/graaflib/algorithm/shortest_path/floyd_warshall_test.cpp`
- Adds `#include <vector>` to `include/graaflib/algorithm/clique_detection/bron_kerbosch.h`, `include/graaflib/algorithm/shortest_path/floyd_warshall.h`, and `include/graaflib/algorithm/topological_sorting/dfs_topological_sorting.h`
- Adds `#include <cstdlib>` to `include/graaflib/properties/vertex_properties.tpp` and `include/graaflib/graph.tpp`

These translation units relied on standard library facilities that were transitively included by other headers. Newer standard library implementations (as shipped with gcc 16 and clang/llvm 23) no longer pull these in transitively, breaking the build. Adding the missing includes fixes this without affecting older toolchains.

Fixes #315

## Test plan
- [x] Configured and built the library and test suite locally with CMake/clang
- [x] Ran the full test suite (`Graaf_test`) — all 753 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)