### PR TITLE
fix: add missing <algorithm> includes for gcc-14 compatibility

### DIFF
--- a/perf/graaflib/bron_kerbosch_benchmark.cpp
+++ b/perf/graaflib/bron_kerbosch_benchmark.cpp
@@ -2,6 +2,7 @@
 #include <graaflib/algorithm/clique_detection/bron_kerbosch.h>
 #include <graaflib/graph.h>
 
+#include <algorithm>
 #include <random>
 #include <vector>
 

--- a/test/graaflib/algorithm/clique_detection/bron_kerbosch_test.cpp
+++ b/test/graaflib/algorithm/clique_detection/bron_kerbosch_test.cpp
@@ -4,6 +4,7 @@
 #include <graaflib/types.h>
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <random>
 
 namespace graaf::algorithm {

--- a/test/graaflib/algorithm/strongly_connected_components/kosaraju_test.cpp
+++ b/test/graaflib/algorithm/strongly_connected_components/kosaraju_test.cpp
@@ -3,6 +3,8 @@
 #include <gtest/gtest.h>
 #include <utils/scenarios/scenarios.h>
 
+#include <algorithm>
+
 namespace graaf::algorithm {
 
 namespace {


### PR DESCRIPTION
## Summary

Fixes #267.

gcc-14 tightened transitive header dependencies in libstdc++ (see [porting_to_gcc-14](https://gcc.gnu.org/gcc-14/porting_to.html#header-dep-changes)), so code that uses `std::sort`/`std::min` etc. now needs to explicitly `#include <algorithm>` instead of relying on it being pulled in transitively by another header.

`tarjan_test.cpp` was already fixed for this in #201, but that fix landed after the `v1.1.1` tag and was never released, and it missed three other files with the same problem:

- [test/graaflib/algorithm/strongly_connected_components/kosaraju_test.cpp](test/graaflib/algorithm/strongly_connected_components/kosaraju_test.cpp) — `std::sort`
- [test/graaflib/algorithm/clique_detection/bron_kerbosch_test.cpp](test/graaflib/algorithm/clique_detection/bron_kerbosch_test.cpp) — `std::sort`
- [perf/graaflib/bron_kerbosch_benchmark.cpp](perf/graaflib/bron_kerbosch_benchmark.cpp) — `std::min`

These currently build only because `<algorithm>` happens to be pulled in transitively by another header on this particular gcc-14/libstdc++ combination — a fragile coincidence, not a guarantee.

## Verification

- Reproduced the exact reported failure by building the `v1.1.1` tag inside a `gcc:14` Docker container (`g++ (GCC) 14.4.0`) with `-DGRAAF_BUILD_TESTS=ON`: fails with `'sort' is not a member of 'std'` at the reported `tarjan_test.cpp` locations.
- Built the full project (tests, benchmarks, examples) on this branch inside the same `gcc:14` container: succeeds cleanly.
- Ran the affected test suites (`*SCC*:*BronKerbosch*`) inside the container: all 12 tests pass.

## Test plan

- [x] `cmake --build build` succeeds under gcc-14.4.0 with tests and benchmarks enabled
- [x] `Graaf_test --gtest_filter='*SCC*:*BronKerbosch*'` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)