### PR TITLE
fix: correct Welsh-Powell coloring to use minimum available color

### DIFF
--- a/include/graaflib/algorithm/coloring/welsh_powell.tpp
+++ b/include/graaflib/algorithm/coloring/welsh_powell.tpp
@@ -5,6 +5,7 @@
 #include <algorithm>
 #include <iostream>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "welsh_powell.h"
@@ -28,17 +29,24 @@ std::unordered_map<vertex_id_t, int> welsh_powell_coloring(const GRAPH& graph) {
   std::unordered_map<vertex_id_t, int> color_map;
 
   for (const auto [_, current_vertex] : degree_vertex_pairs) {
-    int color = 0;  // Start with color 0
-
-    // Check colors of adjacent vertices
+    // Collect the colors already used by neighbors of the current vertex.
+    // Note that this needs to be gathered up front and independent of
+    // iteration order, since graph::get_neighbors() returns an
+    // unordered_set whose iteration order is unspecified.
+    std::unordered_set<int> neighbor_colors;
     for (const auto& neighbor : graph.get_neighbors(current_vertex)) {
-      // If neighbor is already colored with this color, increment the color
-      if (color_map.contains(neighbor) && color_map[neighbor] == color) {
-        color++;
+      if (const auto it{color_map.find(neighbor)}; it != color_map.end()) {
+        neighbor_colors.insert(it->second);
       }
     }
 
-    // Assign the color to the current vertex
+    // Assign the smallest color not used by any neighbor to the current
+    // vertex.
+    int color = 0;
+    while (neighbor_colors.contains(color)) {
+      color++;
+    }
+
     color_map[current_vertex] = color;
   }
 

--- a/test/graaflib/algorithm/coloring/welsh_powell_test.cpp
+++ b/test/graaflib/algorithm/coloring/welsh_powell_test.cpp
@@ -3,8 +3,29 @@
 #include <utils/fixtures/fixtures.h>
 
 #include <unordered_map>
+#include <unordered_set>
 
 namespace graaf::algorithm {
+
+namespace {
+
+// A coloring is proper iff no two vertices connected by an edge share the
+// same color. Note that graph::get_neighbors() returns an unordered_set, so
+// the exact colors assigned to individual vertices are not guaranteed to be
+// stable across STL implementations/platforms - only this invariant is.
+template <typename GRAPH>
+bool is_proper_coloring(const GRAPH& graph,
+                        const std::unordered_map<vertex_id_t, int>& coloring) {
+  for (const auto& [edge_id, edge] : graph.get_edges()) {
+    const auto [u, v]{edge_id};
+    if (coloring.at(u) == coloring.at(v)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+}  // namespace
 
 template <typename T>
 struct WelshPowellTest : public testing::Test {
@@ -46,11 +67,8 @@ TYPED_TEST(WelshPowellTest, BasicGraphColoring) {
   auto coloring = welsh_powell_coloring(graph);
 
   // THEN
-  std::unordered_map<vertex_id_t, int> expected_coloring = {
-      {0, 1}, {2, 1}, {1, 0}};
-
-  // Check if the obtained coloring matches the expected coloring
-  ASSERT_EQ(coloring, expected_coloring);
+  ASSERT_EQ(coloring.size(), 3);
+  ASSERT_TRUE(is_proper_coloring(graph, coloring));
 }
 
 TYPED_TEST(WelshPowellTest, GraphWithNoEdges) {
@@ -101,11 +119,15 @@ TYPED_TEST(WelshPowellTest, CompleteGraph) {
   auto coloring = welsh_powell_coloring(graph);
 
   // THEN
-  std::unordered_map<vertex_id_t, int> expected_coloring = {
-      {0, 3}, {1, 2}, {2, 1}, {3, 0}};
+  ASSERT_TRUE(is_proper_coloring(graph, coloring));
 
-  // Check if the obtained coloring matches the expected coloring
-  ASSERT_EQ(coloring, expected_coloring);
+  // A complete graph on 4 vertices requires exactly 4 distinct colors, since
+  // every vertex is adjacent to every other vertex.
+  std::unordered_set<int> distinct_colors;
+  for (const auto& [vertex_id, color] : coloring) {
+    distinct_colors.insert(color);
+  }
+  ASSERT_EQ(distinct_colors.size(), 4);
 }
 
 TYPED_TEST(WelshPowellTest, DisconnectedComponents) {
@@ -130,13 +152,7 @@ TYPED_TEST(WelshPowellTest, DisconnectedComponents) {
   auto coloring = welsh_powell_coloring(graph);
 
   // THEN
-  // Verify that for each edge, adjacent vertices have different colors
-  for (const auto& [edge_id, edge] : graph.get_edges()) {
-    const auto [u, v]{edge_id};
-    int color_u = coloring[u];
-    int color_v = coloring[v];
-    ASSERT_TRUE(color_u != color_v);
-  }
+  ASSERT_TRUE(is_proper_coloring(graph, coloring));
 }
 
 }  // namespace graaf::algorithm


### PR DESCRIPTION
## Summary

Fixes #284.

The reported test failure (`WelshPowellTest/0.CompleteGraph` producing a different but structurally-similar coloring on macOS/Clang) traces back to a real correctness bug in `welsh_powell_coloring`, not just an overly-strict test.

`graph::get_neighbors()` returns a `std::unordered_set<vertex_id_t>`, whose iteration order is unspecified and can differ across standard library implementations/platforms. The previous coloring loop compared a single running `color` candidate against each neighbor's color one at a time, bumping it on a match — but never re-checked *earlier* neighbors against the new candidate. This means the assigned color depends on neighbor iteration order, and in some orderings it can produce a genuinely **invalid** coloring (a vertex colored the same as one of its already-colored neighbors), not merely a differently-labeled valid one.

I confirmed this with a minimal repro: if a vertex's already-colored neighbors are visited in the order `[color=1, color=0]`, the old algorithm assigns `color=1` to the current vertex, conflicting with the neighbor that already has color 1.

## Changes

- `welsh_powell.tpp`: collect all neighbor colors into a set first, then assign the smallest color not present in that set (the standard greedy-coloring MEX rule). This is order-independent and always produces a proper coloring.
- `welsh_powell_test.cpp`: replaced hardcoded, iteration-order-dependent expected color maps with an `is_proper_coloring` helper that asserts the actual invariant (no two adjacent vertices share a color), plus a deterministic assertion that the complete-graph test uses exactly 4 distinct colors (forced by the graph structure, order-independent).

## Test plan

- [x] `./test/Graaf_test --gtest_filter="WelshPowellTest*"` — all 5 tests pass
- [x] Full suite (`./test/Graaf_test`) — 753/753 tests pass
- [x] `clang-format --dry-run --Werror` clean on both changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)