### PR TITLE
fix: correct swapped DFS arguments in undirected cycle detection

### DIFF
--- a/include/graaflib/algorithm/cycle_detection/dfs_cycle_detection.tpp
+++ b/include/graaflib/algorithm/cycle_detection/dfs_cycle_detection.tpp
@@ -2,6 +2,7 @@
 #include <graaflib/types.h>
 
 #include <algorithm>
+#include <optional>
 #include <unordered_map>
 
 #include "dfs_cycle_detection.h"
@@ -33,23 +34,21 @@ bool do_dfs_directed(
 }
 
 template <typename V, typename E>
-bool do_dfs_undirected(
-    const graph<V, E, graph_type::UNDIRECTED>& graph,
-    std::unordered_map<vertex_id_t, bool>& visited_vertices,
-    std::unordered_map<vertex_id_t, vertex_id_t>& parent_vertices,
-    vertex_id_t parent_vertex, vertex_id_t current) {
+bool do_dfs_undirected(const graph<V, E, graph_type::UNDIRECTED>& graph,
+                        std::unordered_map<vertex_id_t, bool>& visited_vertices,
+                        std::optional<vertex_id_t> parent_vertex,
+                        vertex_id_t current) {
   visited_vertices[current] = true;
 
   for (const auto& neighbour_vertex : graph.get_neighbors(current)) {
-    if (neighbour_vertex == parent_vertex) continue;
+    if (parent_vertex.has_value() && neighbour_vertex == *parent_vertex) {
+      continue;
+    }
 
     if (visited_vertices[neighbour_vertex]) return true;
 
-    parent_vertices[neighbour_vertex] = parent_vertex;
-
-    if (do_dfs_undirected(graph, visited_vertices, parent_vertices,
-                          neighbour_vertex,
-                          parent_vertices[neighbour_vertex])) {
+    if (do_dfs_undirected(graph, visited_vertices, current,
+                          neighbour_vertex)) {
       return true;
     }
   }
@@ -82,13 +81,11 @@ bool dfs_cycle_detection(const graph<V, E, graph_type::UNDIRECTED>& graph) {
   }
 
   std::unordered_map<vertex_id_t, bool> visited_vertices{};
-  std::unordered_map<vertex_id_t, vertex_id_t> parent_vertices{};
 
   for (const auto& vertex : graph.get_vertices()) {
     if (!visited_vertices.contains(vertex.first) &&
-        detail::do_dfs_undirected(graph, visited_vertices, parent_vertices,
-                                  vertex.first,
-                                  parent_vertices[vertex.first])) {
+        detail::do_dfs_undirected(graph, visited_vertices, std::nullopt,
+                                  vertex.first)) {
       return true;
     }
   }

--- a/test/graaflib/algorithm/cycle_detection/dfs_cycle_detection_test.cpp
+++ b/test/graaflib/algorithm/cycle_detection/dfs_cycle_detection_test.cpp
@@ -108,6 +108,26 @@ TYPED_TEST(GraphCycleTest, UndirectedGraphWithCycle) {
   ASSERT_TRUE(cycle);
 }
 
+TYPED_TEST(GraphCycleTest, UndirectedGraphWithCycleAndIsolatedVertex) {
+  // GIVEN a triangle (0, 1, 2) plus an isolated vertex (3), so that
+  // edge_count() == 3 < vertex_count() == 4 and the edge_count >=
+  // vertex_count() fast-path shortcut does not fire.
+  undirected_graph<int, int> graph{};
+
+  const auto vertex_1{graph.add_vertex(10)};
+  const auto vertex_2{graph.add_vertex(20)};
+  const auto vertex_3{graph.add_vertex(30)};
+  [[maybe_unused]] const auto vertex_4{graph.add_vertex(40)};
+
+  graph.add_edge(vertex_1, vertex_2, 100);
+  graph.add_edge(vertex_2, vertex_3, 300);
+  graph.add_edge(vertex_3, vertex_1, 400);
+
+  // checking if graph contains cycle
+  bool cycle = dfs_cycle_detection(graph);
+  ASSERT_TRUE(cycle);
+}
+
 TYPED_TEST(GraphCycleTest, EmptyGraphs) {
   // GIVEN
   directed_graph<int, int> directed_graph{};


### PR DESCRIPTION
## Summary
- `do_dfs_undirected` was invoked with its `parent_vertex`/`current` arguments effectively swapped (both at the initial call site and in the recursive call), so the traversal never actually started at the intended vertex.
- This caused `dfs_cycle_detection` to silently return `false` for undirected graphs that do contain a cycle, whenever `edge_count() >= vertex_count()` fast-path doesn't fire (e.g. a cycle in one component plus an isolated vertex, or multiple components).
- Replaced the buggy `parent_vertices` map (which was only ever populated with the swapped/wrong values) with a `std::optional<vertex_id_t> parent_vertex` parameter — this also correctly represents "no parent" for the root vertex of each DFS tree instead of relying on an implicit zero-initialized sentinel.

## Test plan
- [x] Added `UndirectedGraphWithCycleAndIsolatedVertex` regression test mirroring the issue's repro case (triangle + isolated vertex — 3 edges, 4 vertices — so the `edge_count() >= vertex_count()` shortcut doesn't mask the bug). Fails on `main`, passes with this fix.
- [x] Full test suite (`Graaf_test`, 755 tests) passes.

Fixes #376

🤖 Generated with [Claude Code](https://claude.com/claude-code)