### PR TITLE
fix: floyd_warshall_shortest_paths breaks after remove_vertex

### DIFF
--- a/docs/src/algorithms/shortest-path/floyd-warshall.md
+++ b/docs/src/algorithms/shortest-path/floyd-warshall.md
@@ -17,10 +17,10 @@ Calculates the shortest path between any two vertices.
 ```cpp
 template <typename V, typename E, graph_type T,
           typename WEIGHT_T = decltype(get_weight(std::declval<E>()))>
-std::vector<std::vector<WEIGHT_T>> floyd_warshall_shortest_paths(
-    const graph<V, E, T>& graph);
+std::unordered_map<vertex_id_t, std::unordered_map<vertex_id_t, WEIGHT_T>>
+floyd_warshall_shortest_paths(const graph<V, E, T>& graph);
 ```
 
 - **graph** The graph to extract the shortest path from.
-- **return** Returns a 2D vector of the shortest path. If a path doesn't exist between two vertices, mark it as
-  TYPE_MAX.
+- **return** Returns a map of maps, where `result.at(from).at(to)` is the shortest distance from vertex `from` to
+  vertex `to`. If no path exists between two vertices, there is no corresponding entry.

--- a/include/graaflib/algorithm/shortest_path/floyd_warshall.h
+++ b/include/graaflib/algorithm/shortest_path/floyd_warshall.h
@@ -3,7 +3,7 @@
 #include <graaflib/graph.h>
 #include <graaflib/types.h>
 
-#include <vector>
+#include <unordered_map>
 
 namespace graaf::algorithm {
 /**
@@ -11,21 +11,23 @@ namespace graaf::algorithm {
  *
  * This function computes the shortest paths between all pairs of vertices in a
  * given weighted graph. It works for graphs with negative weight edges as well,
- * but not for graphs with negative weight cycles. The function returns an
- * adjacency matrix representing the shortest distances.
+ * but not for graphs with negative weight cycles. The function returns the
+ * shortest distance between every pair of vertices, keyed by their vertex IDs.
  *
  * @tparam V The type of a graph vertex
  * @tparam E The type of a graph edge
  * @tparam T the graph type (DIRECTED or UNDIRECTED)
  * @tparam WEIGHT_T The weight type of an edge in the graph
  * @param graph The graph object
- * @return A 2D vector where element at [i][j] is the shortest distance from
- * vertex i to vertex j.
+ * @return A map of maps where `result.at(from).at(to)` is the shortest
+ * distance from vertex `from` to vertex `to`. If no path exists between two
+ * vertices, there is no corresponding entry.
  */
 template <typename V, typename E, graph_type T,
           typename WEIGHT_T = decltype(get_weight(std::declval<E>()))>
-std::vector<std::vector<WEIGHT_T>> floyd_warshall_shortest_paths(
-    const graph<V, E, T>& graph);
+[[nodiscard]] std::unordered_map<vertex_id_t,
+                                  std::unordered_map<vertex_id_t, WEIGHT_T>>
+floyd_warshall_shortest_paths(const graph<V, E, T>& graph);
 
 };  // namespace graaf::algorithm
 

--- a/include/graaflib/algorithm/shortest_path/floyd_warshall.tpp
+++ b/include/graaflib/algorithm/shortest_path/floyd_warshall.tpp
@@ -9,11 +9,28 @@
 namespace graaf::algorithm {
 
 template <typename V, typename E, graph_type T, typename WEIGHT_T>
-std::vector<std::vector<WEIGHT_T>> floyd_warshall_shortest_paths(
-    const graph<V, E, T>& graph) {
+std::unordered_map<vertex_id_t, std::unordered_map<vertex_id_t, WEIGHT_T>>
+floyd_warshall_shortest_paths(const graph<V, E, T>& graph) {
   WEIGHT_T ZERO{};
-  std::size_t n = graph.vertex_count();
   auto INF = std::numeric_limits<WEIGHT_T>::max();
+
+  // Vertex IDs are not guaranteed to be contiguous (e.g. after a
+  // remove_vertex call), so we cannot use them directly as indices into a
+  // dense matrix. Instead, we map the graph's (live) vertex IDs to a compact
+  // 0..n-1 index space for the duration of the algorithm, and translate back
+  // to vertex IDs when building the result.
+  std::vector<vertex_id_t> index_to_vertex_id;
+  index_to_vertex_id.reserve(graph.vertex_count());
+  for (const auto& [vertex_id, _] : graph.get_vertices()) {
+    index_to_vertex_id.push_back(vertex_id);
+  }
+
+  const std::size_t n = index_to_vertex_id.size();
+  std::unordered_map<vertex_id_t, std::size_t> vertex_id_to_index;
+  vertex_id_to_index.reserve(n);
+  for (std::size_t index = 0; index < n; ++index) {
+    vertex_id_to_index[index_to_vertex_id[index]] = index;
+  }
 
   std::vector<std::vector<WEIGHT_T>> shortest_paths(
       n, std::vector<WEIGHT_T>(n, INF));
@@ -23,30 +40,45 @@ std::vector<std::vector<WEIGHT_T>> floyd_warshall_shortest_paths(
   }
 
   // Initial weights between vertices
-  for (std::size_t from_vertex = 0; from_vertex < n; ++from_vertex) {
+  for (std::size_t from_index = 0; from_index < n; ++from_index) {
+    const vertex_id_t from_vertex{index_to_vertex_id[from_index]};
     for (const auto& to_vertex : graph.get_neighbors(from_vertex)) {
-      shortest_paths[from_vertex][to_vertex] =
-          std::min(shortest_paths[from_vertex][to_vertex],
+      const std::size_t to_index{vertex_id_to_index.at(to_vertex)};
+      shortest_paths[from_index][to_index] =
+          std::min(shortest_paths[from_index][to_index],
                    get_weight(graph.get_edge(from_vertex, to_vertex)));
     }
   }
 
-  for (std::size_t through_vertex = 0; through_vertex < n; ++through_vertex) {
-    for (std::size_t start_vertex = 0; start_vertex < n; ++start_vertex) {
-      if (shortest_paths[start_vertex][through_vertex] < INF) {
-        for (std::size_t end_vertex = 0; end_vertex < n; ++end_vertex) {
-          if (shortest_paths[through_vertex][end_vertex] < INF) {
-            shortest_paths[start_vertex][end_vertex] =
-                std::min(shortest_paths[start_vertex][end_vertex],
-                         shortest_paths[start_vertex][through_vertex] +
-                             shortest_paths[through_vertex][end_vertex]);
+  for (std::size_t through_index = 0; through_index < n; ++through_index) {
+    for (std::size_t start_index = 0; start_index < n; ++start_index) {
+      if (shortest_paths[start_index][through_index] < INF) {
+        for (std::size_t end_index = 0; end_index < n; ++end_index) {
+          if (shortest_paths[through_index][end_index] < INF) {
+            shortest_paths[start_index][end_index] =
+                std::min(shortest_paths[start_index][end_index],
+                         shortest_paths[start_index][through_index] +
+                             shortest_paths[through_index][end_index]);
           }
         }
       }
     }
   }
 
-  return shortest_paths;
+  std::unordered_map<vertex_id_t, std::unordered_map<vertex_id_t, WEIGHT_T>>
+      result;
+  result.reserve(n);
+  for (std::size_t from_index = 0; from_index < n; ++from_index) {
+    auto& from_result = result[index_to_vertex_id[from_index]];
+    for (std::size_t to_index = 0; to_index < n; ++to_index) {
+      if (shortest_paths[from_index][to_index] < INF) {
+        from_result[index_to_vertex_id[to_index]] =
+            shortest_paths[from_index][to_index];
+      }
+    }
+  }
+
+  return result;
 }
 
 };  // namespace graaf::algorithm

--- a/test/graaflib/algorithm/shortest_path/floyd_warshall_test.cpp
+++ b/test/graaflib/algorithm/shortest_path/floyd_warshall_test.cpp
@@ -13,6 +13,27 @@ struct FloydWarshallTest : public testing::Test {
   using graph_t = typename T::first_type;
   using edge_t = typename T::second_type;
 };
+
+constexpr auto NO_PATH = INT_MAX;
+
+// Converts a dense matrix (indexed in the same order as vertex_ids) into the
+// vertex_id_t-keyed map of maps returned by floyd_warshall_shortest_paths,
+// dropping any entry marked as NO_PATH.
+std::unordered_map<vertex_id_t, std::unordered_map<vertex_id_t, int>>
+to_expected_paths(const std::vector<vertex_id_t>& vertex_ids,
+                   const std::vector<std::vector<int>>& matrix) {
+  std::unordered_map<vertex_id_t, std::unordered_map<vertex_id_t, int>>
+      expected_paths{};
+  for (std::size_t from{0}; from < vertex_ids.size(); ++from) {
+    for (std::size_t to{0}; to < vertex_ids.size(); ++to) {
+      if (matrix[from][to] != NO_PATH) {
+        expected_paths[vertex_ids[from]][vertex_ids[to]] = matrix[from][to];
+      }
+    }
+  }
+  return expected_paths;
+}
+
 }  // namespace
 
 TYPED_TEST_SUITE(FloydWarshallTest, utils::fixtures::weighted_graph_types);
@@ -32,8 +53,9 @@ TYPED_TEST(FloydWarshallTest, UndirectedGraph) {
   graph.add_edge(vertex_3, vertex_1, 300);
 
   auto shortest_paths = floyd_warshall_shortest_paths(graph);
-  std::vector<std::vector<int>> expected_paths = {
-      {0, 100, 300}, {100, 0, 300}, {300, 300, 0}};
+  auto expected_paths = to_expected_paths(
+      {vertex_1, vertex_2, vertex_3},
+      {{0, 100, 300}, {100, 0, 300}, {300, 300, 0}});
 
   ASSERT_EQ(shortest_paths, expected_paths);
 }
@@ -53,8 +75,9 @@ TYPED_TEST(FloydWarshallTest, DirectedGraph) {
   graph.add_edge(vertex_3, vertex_1, 300);
 
   auto shortest_paths = floyd_warshall_shortest_paths(graph);
-  std::vector<std::vector<int>> expected_paths = {
-      {0, 100, 400}, {600, 0, 300}, {300, 400, 0}};
+  auto expected_paths = to_expected_paths(
+      {vertex_1, vertex_2, vertex_3},
+      {{0, 100, 400}, {600, 0, 300}, {300, 400, 0}});
 
   ASSERT_EQ(shortest_paths, expected_paths);
 }
@@ -78,16 +101,15 @@ TYPED_TEST(FloydWarshallTest, DirectedGraphNoCycleNegativeWeight) {
   graph.add_edge(vertex_4, vertex_6, 100);
   graph.add_edge(vertex_5, vertex_2, -75);
 
-  auto NO_PATH = INT_MAX;
-
   auto shortest_paths = floyd_warshall_shortest_paths(graph);
-  std::vector<std::vector<int>> expected_paths = {
-      {0, 100, 150, 80, NO_PATH, 147},
-      {NO_PATH, 0, 50, -20, NO_PATH, 47},
-      {NO_PATH, NO_PATH, 0, NO_PATH, NO_PATH, -3},
-      {NO_PATH, NO_PATH, NO_PATH, 0, NO_PATH, 100},
-      {NO_PATH, -75, -25, -95, 0, -28},
-      {NO_PATH, NO_PATH, NO_PATH, NO_PATH, NO_PATH, 0}};
+  auto expected_paths = to_expected_paths(
+      {vertex_1, vertex_2, vertex_3, vertex_4, vertex_5, vertex_6},
+      {{0, 100, 150, 80, NO_PATH, 147},
+       {NO_PATH, 0, 50, -20, NO_PATH, 47},
+       {NO_PATH, NO_PATH, 0, NO_PATH, NO_PATH, -3},
+       {NO_PATH, NO_PATH, NO_PATH, 0, NO_PATH, 100},
+       {NO_PATH, -75, -25, -95, 0, -28},
+       {NO_PATH, NO_PATH, NO_PATH, NO_PATH, NO_PATH, 0}});
 
   ASSERT_EQ(shortest_paths, expected_paths);
 }
@@ -112,8 +134,9 @@ TYPED_TEST(FloydWarshallTest, DenseDirectedGraph) {
   graph.add_edge(vertex_1, vertex_4, 12);
 
   auto shortest_paths = floyd_warshall_shortest_paths(graph);
-  std::vector<std::vector<int>> expected_paths{
-      {0, 10, 60, 12}, {20, 0, 50, 32}, {23, 3, 0, 35}, {10, 12, 62, 0}};
+  auto expected_paths = to_expected_paths(
+      {vertex_1, vertex_2, vertex_3, vertex_4},
+      {{0, 10, 60, 12}, {20, 0, 50, 32}, {23, 3, 0, 35}, {10, 12, 62, 0}});
 
   ASSERT_EQ(shortest_paths, expected_paths);
 }
@@ -136,8 +159,9 @@ TYPED_TEST(FloydWarshallTest, DenseUndirectedGraph) {
   graph.add_edge(vertex_1, vertex_4, 12);
 
   auto shortest_paths = floyd_warshall_shortest_paths(graph);
-  std::vector<std::vector<int>> expected_paths{
-      {0, 10, 13, 10}, {10, 0, 3, 12}, {13, 3, 0, 15}, {10, 12, 15, 0}};
+  auto expected_paths = to_expected_paths(
+      {vertex_1, vertex_2, vertex_3, vertex_4},
+      {{0, 10, 13, 10}, {10, 0, 3, 12}, {13, 3, 0, 15}, {10, 12, 15, 0}});
 
   ASSERT_EQ(shortest_paths, expected_paths);
 }
@@ -169,18 +193,18 @@ TYPED_TEST(FloydWarshallTest, UndirectedGraphTwoComponents) {
   graph.add_edge(vertex_6, vertex_8, 2);
   graph.add_edge(vertex_7, vertex_8, 3);
 
-  auto NO_PATH = INT_MAX;
-
   auto shortest_paths = floyd_warshall_shortest_paths(graph);
-  std::vector<std::vector<int>> expected_paths{
-      {0, 12, 11, 15, 6, NO_PATH, NO_PATH, NO_PATH},
-      {12, 0, 21, 15, 14, NO_PATH, NO_PATH, NO_PATH},
-      {11, 21, 0, 7, 7, NO_PATH, NO_PATH, NO_PATH},
-      {15, 15, 7, 0, 9, NO_PATH, NO_PATH, NO_PATH},
-      {6, 14, 7, 9, 0, NO_PATH, NO_PATH, NO_PATH},
-      {NO_PATH, NO_PATH, NO_PATH, NO_PATH, NO_PATH, 0, 4, 2},
-      {NO_PATH, NO_PATH, NO_PATH, NO_PATH, NO_PATH, 4, 0, 3},
-      {NO_PATH, NO_PATH, NO_PATH, NO_PATH, NO_PATH, 2, 3, 0}};
+  auto expected_paths = to_expected_paths(
+      {vertex_1, vertex_2, vertex_3, vertex_4, vertex_5, vertex_6, vertex_7,
+       vertex_8},
+      {{0, 12, 11, 15, 6, NO_PATH, NO_PATH, NO_PATH},
+       {12, 0, 21, 15, 14, NO_PATH, NO_PATH, NO_PATH},
+       {11, 21, 0, 7, 7, NO_PATH, NO_PATH, NO_PATH},
+       {15, 15, 7, 0, 9, NO_PATH, NO_PATH, NO_PATH},
+       {6, 14, 7, 9, 0, NO_PATH, NO_PATH, NO_PATH},
+       {NO_PATH, NO_PATH, NO_PATH, NO_PATH, NO_PATH, 0, 4, 2},
+       {NO_PATH, NO_PATH, NO_PATH, NO_PATH, NO_PATH, 4, 0, 3},
+       {NO_PATH, NO_PATH, NO_PATH, NO_PATH, NO_PATH, 2, 3, 0}});
 
   ASSERT_EQ(shortest_paths, expected_paths);
 }
@@ -212,20 +236,45 @@ TYPED_TEST(FloydWarshallTest, DirectedGraphTwoComponents) {
   graph.add_edge(vertex_6, vertex_8, 2);
   graph.add_edge(vertex_8, vertex_7, 3);
 
-  auto NO_PATH = INT_MAX;
-
   auto shortest_paths = floyd_warshall_shortest_paths(graph);
-  std::vector<std::vector<int>> expected_paths{
-      {0, 12, 11, 15, 6, NO_PATH, NO_PATH, NO_PATH},
-      {12, 0, 21, 15, 14, NO_PATH, NO_PATH, NO_PATH},
-      {11, 21, 0, 7, 7, NO_PATH, NO_PATH, NO_PATH},
-      {15, 15, 7, 0, 9, NO_PATH, NO_PATH, NO_PATH},
-      {6, 14, 7, 9, 0, NO_PATH, NO_PATH, NO_PATH},
-      {NO_PATH, NO_PATH, NO_PATH, NO_PATH, NO_PATH, 0, 4, 2},
-      {NO_PATH, NO_PATH, NO_PATH, NO_PATH, NO_PATH, 4, 0, 3},
-      {NO_PATH, NO_PATH, NO_PATH, NO_PATH, NO_PATH, 2, 3, 0}};
+  auto expected_paths = to_expected_paths(
+      {vertex_1, vertex_2, vertex_3, vertex_4, vertex_5, vertex_6, vertex_7,
+       vertex_8},
+      {{0, 12, 11, 15, 6, NO_PATH, NO_PATH, NO_PATH},
+       {12, 0, 21, 15, 14, NO_PATH, NO_PATH, NO_PATH},
+       {11, 21, 0, 7, 7, NO_PATH, NO_PATH, NO_PATH},
+       {15, 15, 7, 0, 9, NO_PATH, NO_PATH, NO_PATH},
+       {6, 14, 7, 9, 0, NO_PATH, NO_PATH, NO_PATH},
+       {NO_PATH, NO_PATH, NO_PATH, NO_PATH, NO_PATH, 0, 4, 2},
+       {NO_PATH, NO_PATH, NO_PATH, NO_PATH, NO_PATH, 4, 0, 3},
+       {NO_PATH, NO_PATH, NO_PATH, NO_PATH, NO_PATH, 2, 3, 0}});
 
   ASSERT_EQ(shortest_paths, expected_paths);
+}
+
+TYPED_TEST(FloydWarshallTest, GraphWithNonContiguousVertexIdsAfterRemoval) {
+  // GIVEN a graph where a vertex has been removed, so the remaining vertex
+  // IDs are not contiguous (0, 2, 3 - vertex 1 was removed).
+  directed_graph<int, int> graph{};
+
+  const auto vertex_1{graph.add_vertex(10)};
+  const auto vertex_2{graph.add_vertex(20)};
+  const auto vertex_3{graph.add_vertex(30)};
+  const auto vertex_4{graph.add_vertex(40)};
+
+  graph.remove_vertex(vertex_2);
+
+  graph.add_edge(vertex_1, vertex_3, 5);
+  graph.add_edge(vertex_3, vertex_4, 7);
+
+  // WHEN / THEN this must neither throw nor produce out-of-bounds access.
+  auto shortest_paths = floyd_warshall_shortest_paths(graph);
+  auto expected_paths =
+      to_expected_paths({vertex_1, vertex_3, vertex_4},
+                         {{0, 5, 12}, {NO_PATH, 0, 7}, {NO_PATH, NO_PATH, 0}});
+
+  ASSERT_EQ(shortest_paths, expected_paths);
+  ASSERT_FALSE(shortest_paths.contains(vertex_2));
 }
 
 }  // namespace graaf::algorithm


### PR DESCRIPTION
## Summary
- `floyd_warshall_shortest_paths` sized its distance matrix by `vertex_count()` and indexed it directly with raw `vertex_id_t` values, assuming vertex IDs are contiguous `0..n-1`. `remove_vertex` does not compact or reassign remaining IDs, so this assumption breaks as soon as any vertex has been removed — leading to out-of-bounds writes into the distance matrix (undefined behavior) from entirely ordinary API usage.
- **This is a breaking API change** : the return type changes from `std::vector<std::vector<WEIGHT_T>>` to `std::unordered_map<vertex_id_t, std::unordered_map<vertex_id_t, WEIGHT_T>>`, keyed by real vertex IDs — matching the convention `dijkstra_shortest_paths` already uses elsewhere in the library, instead of introducing a second "compact index" coordinate space that callers would have to reason about.
- Internally, the `O(V³)` relaxation still runs against a dense, compact-indexed matrix (vertex IDs mapped to `0..n-1` for the algorithm's duration) for cache-friendly performance — this is converted to the vertex-ID-keyed result in a single `O(V²)` pass at the end, so correctness doesn't come at the cost of the dense-matrix performance Floyd-Warshall is chosen for.
- Added `[[nodiscard]]` to the declaration, matching `dijkstra_shortest_paths`.
- Updated the docs page and all existing tests for the new return type; no existing test's expected values changed, only the type they're expressed as.

## Test plan
- [x] Added `GraphWithNonContiguousVertexIdsAfterRemoval` regression test: adds 4 vertices, removes one, and confirms `floyd_warshall_shortest_paths` runs correctly against the remaining non-contiguous IDs.
- [x] Verified against the pre-fix code with a standalone repro compiled with `-fsanitize=address,undefined` and libc++ hardened assertions (`_LIBCPP_HARDENING_MODE_DEBUG`): the old code reliably traps on an out-of-bounds `vector[]` write for this exact scenario (`vector[] index out of bounds`); the fixed code runs cleanly under the same sanitizer settings.
- [x] Full test suite (`Graaf_test`, 771 tests) passes.

Fixes #377

🤖 Generated with [Claude Code](https://claude.com/claude-code)