### PR TITLE
fix: floyd_warshall_shortest_paths breaks after remove_vertex (non-breaking)

### DIFF
--- a/docs/src/algorithms/shortest-path/floyd-warshall.md
+++ b/docs/src/algorithms/shortest-path/floyd-warshall.md
@@ -23,4 +23,5 @@ std::vector<std::vector<WEIGHT_T>> floyd_warshall_shortest_paths(
 
 - **graph** The graph to extract the shortest path from.
 - **return** Returns a 2D vector of the shortest path. If a path doesn't exist between two vertices, mark it as
-  TYPE_MAX.
+  TYPE_MAX. Rows/columns are indexed by the ascending order of the graph's vertex IDs: if no vertex has been
+  removed from the graph, index `i` corresponds exactly to vertex `i`.

--- a/include/graaflib/algorithm/shortest_path/floyd_warshall.h
+++ b/include/graaflib/algorithm/shortest_path/floyd_warshall.h
@@ -14,13 +14,20 @@ namespace graaf::algorithm {
  * but not for graphs with negative weight cycles. The function returns an
  * adjacency matrix representing the shortest distances.
  *
+ * Rows/columns are indexed by the ascending order of the graph's (live)
+ * vertex IDs. If no vertex has ever been removed from the graph, vertex IDs
+ * are contiguous starting at 0, so index i corresponds exactly to vertex i.
+ * If vertices have been removed, index i corresponds to the i-th smallest
+ * remaining vertex ID rather than vertex ID i itself.
+ *
  * @tparam V The type of a graph vertex
  * @tparam E The type of a graph edge
  * @tparam T the graph type (DIRECTED or UNDIRECTED)
  * @tparam WEIGHT_T The weight type of an edge in the graph
  * @param graph The graph object
  * @return A 2D vector where element at [i][j] is the shortest distance from
- * vertex i to vertex j.
+ * the vertex at index i to the vertex at index j (see above for how indices
+ * map to vertex IDs).
  */
 template <typename V, typename E, graph_type T,
           typename WEIGHT_T = decltype(get_weight(std::declval<E>()))>

--- a/include/graaflib/algorithm/shortest_path/floyd_warshall.tpp
+++ b/include/graaflib/algorithm/shortest_path/floyd_warshall.tpp
@@ -1,7 +1,9 @@
 #pragma once
 #include <graaflib/algorithm/shortest_path/floyd_warshall.h>
 
+#include <algorithm>
 #include <limits>
+#include <unordered_map>
 #include <vector>
 
 #include "floyd_warshall.h"
@@ -12,8 +14,29 @@ template <typename V, typename E, graph_type T, typename WEIGHT_T>
 std::vector<std::vector<WEIGHT_T>> floyd_warshall_shortest_paths(
     const graph<V, E, T>& graph) {
   WEIGHT_T ZERO{};
-  std::size_t n = graph.vertex_count();
   auto INF = std::numeric_limits<WEIGHT_T>::max();
+
+  // Vertex IDs are not guaranteed to be contiguous (e.g. after a
+  // remove_vertex call), so we cannot use them directly as indices into a
+  // dense matrix. Instead, we map the graph's (live) vertex IDs to a compact
+  // 0..n-1 index space for the duration of the algorithm. IDs are sorted
+  // ascending before assigning indices, so for the common case where vertex
+  // IDs already form a contiguous 0..n-1 range (i.e. no vertex has been
+  // removed), index i and vertex ID i coincide and the result matches the
+  // long-standing [i][j] == "vertex i to vertex j" contract exactly.
+  std::vector<vertex_id_t> index_to_vertex_id;
+  index_to_vertex_id.reserve(graph.vertex_count());
+  for (const auto& [vertex_id, _] : graph.get_vertices()) {
+    index_to_vertex_id.push_back(vertex_id);
+  }
+  std::sort(index_to_vertex_id.begin(), index_to_vertex_id.end());
+
+  const std::size_t n = index_to_vertex_id.size();
+  std::unordered_map<vertex_id_t, std::size_t> vertex_id_to_index;
+  vertex_id_to_index.reserve(n);
+  for (std::size_t index = 0; index < n; ++index) {
+    vertex_id_to_index[index_to_vertex_id[index]] = index;
+  }
 
   std::vector<std::vector<WEIGHT_T>> shortest_paths(
       n, std::vector<WEIGHT_T>(n, INF));
@@ -23,10 +46,12 @@ std::vector<std::vector<WEIGHT_T>> floyd_warshall_shortest_paths(
   }
 
   // Initial weights between vertices
-  for (std::size_t from_vertex = 0; from_vertex < n; ++from_vertex) {
+  for (std::size_t from_index = 0; from_index < n; ++from_index) {
+    const vertex_id_t from_vertex{index_to_vertex_id[from_index]};
     for (const auto& to_vertex : graph.get_neighbors(from_vertex)) {
-      shortest_paths[from_vertex][to_vertex] =
-          std::min(shortest_paths[from_vertex][to_vertex],
+      const std::size_t to_index{vertex_id_to_index.at(to_vertex)};
+      shortest_paths[from_index][to_index] =
+          std::min(shortest_paths[from_index][to_index],
                    get_weight(graph.get_edge(from_vertex, to_vertex)));
     }
   }

--- a/test/graaflib/algorithm/shortest_path/floyd_warshall_test.cpp
+++ b/test/graaflib/algorithm/shortest_path/floyd_warshall_test.cpp
@@ -228,4 +228,33 @@ TYPED_TEST(FloydWarshallTest, DirectedGraphTwoComponents) {
   ASSERT_EQ(shortest_paths, expected_paths);
 }
 
+TYPED_TEST(FloydWarshallTest, GraphWithNonContiguousVertexIdsAfterRemoval) {
+  // GIVEN a graph where a vertex has been removed, so the remaining vertex
+  // IDs are not contiguous (0, 2, 3 - vertex 1 was removed).
+  directed_graph<int, int> graph{};
+
+  const auto vertex_1{graph.add_vertex(10)};
+  const auto vertex_2{graph.add_vertex(20)};
+  const auto vertex_3{graph.add_vertex(30)};
+  const auto vertex_4{graph.add_vertex(40)};
+
+  graph.remove_vertex(vertex_2);
+
+  graph.add_edge(vertex_1, vertex_3, 5);
+  graph.add_edge(vertex_3, vertex_4, 7);
+
+  auto NO_PATH = INT_MAX;
+
+  // WHEN this must neither throw nor produce out-of-bounds access.
+  // THEN the result is indexed by ascending order of the remaining vertex
+  // IDs (0, 2, 3), i.e. index 0 -> vertex_1, index 1 -> vertex_3, index 2 ->
+  // vertex_4.
+  auto shortest_paths = floyd_warshall_shortest_paths(graph);
+  std::vector<std::vector<int>> expected_paths{
+      {0, 5, 12}, {NO_PATH, 0, 7}, {NO_PATH, NO_PATH, 0}};
+
+  ASSERT_EQ(shortest_paths, expected_paths);
+  ASSERT_EQ(shortest_paths.size(), 3);
+}
+
 }  // namespace graaf::algorithm


### PR DESCRIPTION
## Summary
- `floyd_warshall_shortest_paths` sized its distance matrix by `vertex_count()` and indexed it directly with raw `vertex_id_t` values, assuming vertex IDs are contiguous `0..n-1`. `remove_vertex` does not compact or reassign remaining IDs, so this assumption breaks as soon as any vertex has been removed — leading to out-of-bounds writes into the distance matrix (undefined behavior) from entirely ordinary API usage.
- Alternative to #386: that PR fixes the same bug but changes the return type from `std::vector<std::vector<WEIGHT_T>>` to `std::unordered_map<vertex_id_t, std::unordered_map<vertex_id_t, WEIGHT_T>>`. Since we're aiming for no breaking API changes ahead of the 1.2 release, this PR fixes the bug while keeping the original return type.
- Internally, live vertex IDs are mapped to a compact, **sorted ascending** `0..n-1` index space for the duration of the `O(V^3)` relaxation (dense, cache-friendly). Sorting ascending means that whenever no vertex has ever been removed from the graph (i.e. vertex IDs are already contiguous `0..n-1`, which is the case for every existing caller today), index `i` coincides with vertex ID `i` — so results are byte-for-byte identical to the current behavior for that case.
- For a graph with removed vertices, index `i` now corresponds to the i-th smallest remaining vertex ID rather than crashing. This is documented on the function and in the docs page. No new API surface (e.g. id<->index maps) is introduced, matching the "just fix the crash, don't change the contract" scope of this PR.
- Added a regression test mirroring #386's: adds 4 vertices, removes one, and confirms `floyd_warshall_shortest_paths` runs correctly against the remaining non-contiguous IDs.

## Test plan
- [x] Added `GraphWithNonContiguousVertexIdsAfterRemoval` regression test; all pre-existing tests are unchanged (same `std::vector<std::vector<int>>` expectations as before) and still pass.
- [x] Verified under `-fsanitize=address,undefined`: no out-of-bounds access or UB for the non-contiguous-ID regression case.
- [x] Full test suite (`Graaf_test`, 771 tests) passes.

Fixes #377

🤖 Generated with [Claude Code](https://claude.com/claude-code)