### PR TITLE
fix: get_transposed_graph drops vertices with no incident edges

### DIFF
--- a/include/graaflib/algorithm/utils.tpp
+++ b/include/graaflib/algorithm/utils.tpp
@@ -7,21 +7,13 @@ template <typename VERTEX_T, typename EDGE_T>
 directed_graph<VERTEX_T, EDGE_T> get_transposed_graph(
     const directed_graph<VERTEX_T, EDGE_T>& graph) {
   directed_graph<VERTEX_T, EDGE_T> transposed_graph{};
+
+  for (const auto& [vertex_id, vertex_value] : graph.get_vertices()) {
+    transposed_graph.add_vertex(vertex_value, vertex_id);
+  }
+
   for (auto [edge_vertices, edge_type] : graph.get_edges()) {
     const auto [vertex_id_lhs, vertex_id_rhs] = edge_vertices;
-
-    auto vertex_value_lhs = graph.get_vertex(vertex_id_lhs);
-    auto vertex_value_rhs = graph.get_vertex(vertex_id_rhs);
-
-    if (!transposed_graph.has_vertex(vertex_id_lhs)) {
-      auto vertex_id = transposed_graph.add_vertex(std::move(vertex_value_lhs),
-                                                   vertex_id_lhs);
-    }
-
-    if (!transposed_graph.has_vertex(vertex_id_rhs)) {
-      auto vertex_id = transposed_graph.add_vertex(std::move(vertex_value_rhs),
-                                                   vertex_id_rhs);
-    }
 
     transposed_graph.add_edge(vertex_id_rhs, vertex_id_lhs,
                               std::move(edge_type));

--- a/test/graaflib/algorithm/utils_test.cpp
+++ b/test/graaflib/algorithm/utils_test.cpp
@@ -46,10 +46,20 @@ TEST(UtilsTest, TransposePreservesIsolatedVertices) {
   graph_t transposed_graph = get_transposed_graph(graph);
 
   // THEN
-  EXPECT_EQ(transposed_graph.vertex_count(), 3);
-  EXPECT_TRUE(transposed_graph.has_vertex(vertex_id_3));
+  // Fully pin down the transposed graph: exactly the same three vertices,
+  // with their original values, and exactly one edge, reversed.
+  ASSERT_EQ(transposed_graph.vertex_count(), 3);
+  EXPECT_EQ(transposed_graph.get_vertex(vertex_id_1), 1);
+  EXPECT_EQ(transposed_graph.get_vertex(vertex_id_2), 2);
+  EXPECT_EQ(transposed_graph.get_vertex(vertex_id_3), 3);
+
+  ASSERT_EQ(transposed_graph.edge_count(), 1);
+  EXPECT_TRUE(transposed_graph.has_edge(vertex_id_2, vertex_id_1));
   EXPECT_EQ(get_weight(transposed_graph.get_edge(vertex_id_2, vertex_id_1)),
             100);
+
+  // The original-direction edge should not survive the transpose.
+  EXPECT_FALSE(transposed_graph.has_edge(vertex_id_1, vertex_id_2));
 }
 
 }  // namespace graaf

--- a/test/graaflib/algorithm/utils_test.cpp
+++ b/test/graaflib/algorithm/utils_test.cpp
@@ -33,4 +33,23 @@ TEST(UtilsTest, Transpose) {
             300);
 }
 
+TEST(UtilsTest, TransposePreservesIsolatedVertices) {
+  // GIVEN
+  using graph_t = directed_graph<int, int>;
+  graph_t graph{};
+  const auto vertex_id_1 = graph.add_vertex(1);
+  const auto vertex_id_2 = graph.add_vertex(2);
+  const auto vertex_id_3 = graph.add_vertex(3);
+  graph.add_edge(vertex_id_1, vertex_id_2, 100);
+
+  // WHEN
+  graph_t transposed_graph = get_transposed_graph(graph);
+
+  // THEN
+  EXPECT_EQ(transposed_graph.vertex_count(), 3);
+  EXPECT_TRUE(transposed_graph.has_vertex(vertex_id_3));
+  EXPECT_EQ(get_weight(transposed_graph.get_edge(vertex_id_2, vertex_id_1)),
+            100);
+}
+
 }  // namespace graaf


### PR DESCRIPTION
## Summary
- `get_transposed_graph` built the result graph only by iterating `graph.get_edges()`, so vertices with no incident edges were never added — silently dropped from the transposed graph.
- Fixed by first copying all vertices from the source graph via `graph.get_vertices()`, then adding the (reversed) edges.
- Added a regression test, `UtilsTest.TransposePreservesIsolatedVertices`, covering a graph with an isolated vertex.

## Impact
Consumers of the transposed graph (e.g. Kosaraju's SCC algorithm) previously got a graph missing isolated vertices, which could produce wrong results downstream — an isolated vertex should always be its own SCC.

Fixes #380

## Test plan
- [x] Added `UtilsTest.TransposePreservesIsolatedVertices` reproducing the issue
- [x] Ran full test suite locally: `772 tests from 208 test suites ran. [PASSED] 772 tests.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)