### PR TITLE
docs: fix throws documentation to match std::invalid_argument

### DIFF
--- a/include/graaflib/graph.h
+++ b/include/graaflib/graph.h
@@ -103,7 +103,7 @@ class graph {
    *
    * @param vertex_id The ID of the vertex
    * @return vertex_t - A reference to the vertex
-   * @throws out_of_range exception - If vertex_id does not exist within the
+   * @throws std::invalid_argument - If vertex_id does not exist within the
    * graph
    */
   [[nodiscard]] vertex_t& get_vertex(vertex_id_t vertex_id);
@@ -125,7 +125,7 @@ class graph {
    * @param  vertex_id_rhs The ID of the second vertex
    * @return edge_t - Shared pointer to either the provided edge or to
    * primitive_numeric_adapter.
-   * @throws out_of_range exception - If no edge exists between the two vertices
+   * @throws std::invalid_argument - If no edge exists between the two vertices
    */
   [[nodiscard]] edge_t& get_edge(vertex_id_t vertex_id_lhs,
                                  vertex_id_t vertex_id_rhs);
@@ -149,7 +149,7 @@ class graph {
    * @param  edge_id The ID of the edge.
    * @return edge_t - Shared pointer to either the provided edge or to
    * primitive_numeric_adapter.
-   * @throws out_of_range exception - If no edge exists between the two vertices
+   * @throws std::invalid_argument - If no edge exists between the two vertices
    */
   [[nodiscard]] edge_t& get_edge(const edge_id_t& edge_id);
 
@@ -159,7 +159,7 @@ class graph {
    * @param  edge_id The ID of the edge.
    * @return edge_t - Shared pointer to either the provided edge or to
    * primitive_numeric_adapter.
-   * @throws out_of_range exception - If no edge exists between the two vertices
+   * @throws std::invalid_argument - If no edge exists between the two vertices
    */
   [[nodiscard]] const edge_t& get_edge(const edge_id_t& edge_id) const;
 
@@ -200,7 +200,8 @@ class graph {
    * Add a new edge between two existing vertices
    *
    * @param  vertex_id The ID of the vertex
-   * @throws out_of_range - If either of the vertices do not exist in graph
+   * @throws std::invalid_argument - If either of the vertices do not exist in
+   * graph
    */
   void add_edge(vertex_id_t vertex_id_lhs, vertex_id_t vertex_id_rhs,
                 auto&& edge);


### PR DESCRIPTION
## Summary
- The header doc comments for `get_vertex`, `get_edge` (all overloads), and `add_edge` said `@throws out_of_range exception`, but the implementations in `graph.tpp` throw `std::invalid_argument` in every case.
- Updated the docs to match the actual, already-working behavior instead of changing the thrown exception type — changing the implementation instead would break any caller currently (correctly) catching `std::invalid_argument`, since `std::out_of_range` and `std::invalid_argument` are sibling types under `std::logic_error` and neither derives from the other.

## Test plan
- [x] Doc-only change; existing `graph_test.cpp` already catches `std::invalid_argument` for these calls, confirming the documented contract now matches reality.

Fixes #383

🤖 Generated with [Claude Code](https://claude.com/claude-code)