### PR TITLE
fix: add_edge throws on duplicate edge instead of silently discarding it

### DIFF
--- a/include/graaflib/graph.h
+++ b/include/graaflib/graph.h
@@ -185,7 +185,7 @@ class graph {
    * @param  vertex The vertex to be added
    * @param  id The requested ID for the new vertex
    * @return vertices_id_t - The ID of the new vertex
-   * @throws id_taken exception - If the relevant ID is already in use
+   * @throws std::invalid_argument - If the relevant ID is already in use
    */
   vertex_id_t add_vertex(auto&& vertex, vertex_id_t id);
 
@@ -202,6 +202,9 @@ class graph {
    * @param  vertex_id The ID of the vertex
    * @throws std::invalid_argument - If either of the vertices do not exist in
    * graph
+   * @throws std::invalid_argument - If an edge already exists between the two
+   * vertices. Use get_edge() and modify the returned edge in place, or call
+   * remove_edge() first, to update an existing edge.
    */
   void add_edge(vertex_id_t vertex_id_lhs, vertex_id_t vertex_id_rhs,
                 auto&& edge);

--- a/include/graaflib/graph.tpp
+++ b/include/graaflib/graph.tpp
@@ -182,6 +182,14 @@ void graph<VERTEX_T, EDGE_T, GRAPH_TYPE_V>::add_edge(vertex_id_t vertex_id_lhs,
         std::to_string(vertex_id_rhs) + "] not found in graph."};
   }
 
+  if (has_edge(vertex_id_lhs, vertex_id_rhs)) {
+    // TODO(bluppes): replace with std::format once Clang supports it
+    throw std::invalid_argument{
+        "An edge already exists between vertices with ID [" +
+        std::to_string(vertex_id_lhs) + "] and [" +
+        std::to_string(vertex_id_rhs) + "]."};
+  }
+
   using enum graph_type;
   if constexpr (GRAPH_TYPE_V == DIRECTED) {
     adjacency_list_[vertex_id_lhs].insert(vertex_id_rhs);

--- a/perf/graaflib/add_edge_benchmark.cpp
+++ b/perf/graaflib/add_edge_benchmark.cpp
@@ -21,13 +21,15 @@ template <typename EDGE_T>
 static void bm_add_primitive_numeric_edge(benchmark::State& state) {
   const auto number_of_edges{static_cast<size_t>(state.range(0))};
 
-  graaf::directed_graph<int, int> graph{};
-
   // We create enough vertices to construct the requested number of edges
   const auto number_of_vertices{number_of_edges + 1};
-  const auto vertices{create_vertices(graph, number_of_vertices)};
 
   for (auto _ : state) {
+    state.PauseTiming();
+    graaf::directed_graph<int, int> graph{};
+    const auto vertices{create_vertices(graph, number_of_vertices)};
+    state.ResumeTiming();
+
     for (size_t i{0}; i < number_of_edges; ++i) {
       graph.add_edge(vertices[i], vertices[i + 1], i);
     }
@@ -42,13 +44,15 @@ struct edge {
 static void bm_add_user_defined_edge(benchmark::State& state) {
   const auto number_of_edges{static_cast<size_t>(state.range(0))};
 
-  graaf::directed_graph<int, edge> graph{};
-
   // We create enough vertices to construct the requested number of edges
   const auto number_of_vertices{number_of_edges + 1};
-  const auto vertices{create_vertices(graph, number_of_vertices)};
 
   for (auto _ : state) {
+    state.PauseTiming();
+    graaf::directed_graph<int, edge> graph{};
+    const auto vertices{create_vertices(graph, number_of_vertices)};
+    state.ResumeTiming();
+
     for (size_t i{0}; i < number_of_edges; ++i) {
       graph.add_edge(vertices[i], vertices[i + 1], edge{});
     }

--- a/perf/graaflib/bron_kerbosch_benchmark.cpp
+++ b/perf/graaflib/bron_kerbosch_benchmark.cpp
@@ -32,10 +32,13 @@ void add_clique(graaf::undirected_graph<int, EDGE_T>& graph,
   // We are in range of vector of vertices
   size_t end_vertex = std::min(start_vertex + clique_size, vertices.size());
 
-  // Constructing a clique
+  // Constructing a clique. Some of these edges may already exist (e.g. from
+  // a connecting path built before the clique), so only add what is missing.
   for (size_t i{start_vertex}; i < end_vertex; ++i) {
     for (size_t j{i + 1}; j < end_vertex; ++j) {
-      graph.add_edge(vertices[i], vertices[j], 1);
+      if (!graph.has_edge(vertices[i], vertices[j])) {
+        graph.add_edge(vertices[i], vertices[j], 1);
+      }
     }
   }
 }

--- a/perf/graaflib/prim_benchmark.cpp
+++ b/perf/graaflib/prim_benchmark.cpp
@@ -60,7 +60,8 @@ constexpr std::size_t MAX_SUBGRAPH_VERTICES{2'400};
         }
 
         if (connected_subgraph.has_vertex(source) &&
-            connected_subgraph.has_vertex(target)) {
+            connected_subgraph.has_vertex(target) &&
+            !connected_subgraph.has_edge(source, target)) {
           connected_subgraph.add_edge(source, target, 1);
         }
       },

--- a/perf/graaflib/utils/dataset_reader.cpp
+++ b/perf/graaflib/utils/dataset_reader.cpp
@@ -62,7 +62,12 @@ graph_t construct_graph_from_file(const dataset& dataset_name) {
       graph.add_vertex(no_data{}, target);
     }
 
-    graph.add_edge(source, target, UNIT_WEIGHT);
+    // The source dataset is directed and may contain reciprocal edges
+    // (source->target and target->source), which map to the same edge in
+    // this undirected graph. Skip edges we've already added.
+    if (!graph.has_edge(source, target)) {
+      graph.add_edge(source, target, UNIT_WEIGHT);
+    }
   }
 
   return graph;

--- a/test/graaflib/algorithm/shortest_path/floyd_warshall_test.cpp
+++ b/test/graaflib/algorithm/shortest_path/floyd_warshall_test.cpp
@@ -133,7 +133,6 @@ TYPED_TEST(FloydWarshallTest, DenseUndirectedGraph) {
   graph.add_edge(vertex_4, vertex_1, 10);
   graph.add_edge(vertex_4, vertex_3, 75);
   graph.add_edge(vertex_4, vertex_2, 12);
-  graph.add_edge(vertex_1, vertex_4, 12);
 
   auto shortest_paths = floyd_warshall_shortest_paths(graph);
   std::vector<std::vector<int>> expected_paths{

--- a/test/graaflib/graph_test.cpp
+++ b/test/graaflib/graph_test.cpp
@@ -143,6 +143,36 @@ TYPED_TEST(GraphTest, AddEdge) {
   EXPECT_FALSE(graph.has_edge(vertex_id_1, vertex_id_2));
 }
 
+TYPED_TEST(GraphTest, AddDuplicateEdge) {
+  using graph_t = typename TestFixture::graph_t;
+
+  graph_t graph{};
+  const auto vertex_id_1{graph.add_vertex(10)};
+  const auto vertex_id_2{graph.add_vertex(20)};
+
+  graph.add_edge(vertex_id_1, vertex_id_2, 100);
+
+  ASSERT_THROW(
+      {
+        try {
+          // Adding an edge which already exists should throw rather than
+          // silently discarding the new value or overwriting the old one.
+          graph.add_edge(vertex_id_1, vertex_id_2, 200);
+        } catch (const std::invalid_argument &ex) {
+          EXPECT_EQ(ex.what(),
+                    fmt::format("An edge already exists between vertices "
+                                "with ID [{}] and [{}].",
+                                vertex_id_1, vertex_id_2));
+          throw;
+        }
+      },
+      std::invalid_argument);
+
+  // The original edge value should be unaffected
+  EXPECT_EQ(graph.edge_count(), 1);
+  EXPECT_EQ(get_weight(graph.get_edge(vertex_id_1, vertex_id_2)), 100);
+}
+
 TYPED_TEST(GraphTest, VertexTests) {
   using graph_t = typename TestFixture::graph_t;
   graph_t graph{};


### PR DESCRIPTION
## Summary

`add_edge` previously used insert-if-absent semantics (`edges_.emplace(...)`): calling it a second time for an already-existing edge silently discarded the new value, with no exception or return value indicating anything happened. This is inconsistent with `add_vertex(vertex, id)`, which throws `std::invalid_argument` when the requested ID is already in use.

Fixes #384.

## Change

- `add_edge` now throws `std::invalid_argument` when an edge already exists between the given vertices, matching the existing `add_vertex(vertex, id)` convention. To update an edge, use `get_edge()` and modify it in place, or `remove_edge()` first.
- No API signature changes — this is a behavioral fix, not a breaking change to the public interface.
- Updated doc comments in `graph.h` (also fixed a stale `@throws id_taken` comment that didn't match the actual exception type thrown by `add_vertex`).
- Added a regression test (`AddDuplicateEdge`) covering the new exception and verifying the original edge value is left untouched.

## Fallout from the old silent no-op

Tightening this behavior surfaced several places in the repo that were unknowingly relying on the old no-op/overwrite-is-ignored semantics:

- **`floyd_warshall_test.cpp`**: `DenseUndirectedGraph` added the same undirected edge (`vertex_1`, `vertex_4`) twice with different weights (10, then 12). The expected shortest-path matrix already assumed the *first* value (10) silently won — i.e. this test was inadvertently exercising the exact bug from the issue. Removed the erroneous duplicate call.
- **`perf/graaflib/add_edge_benchmark.cpp`**: the benchmarked graph was built once outside the timed loop, then the same edges were re-added on every timed iteration. Now rebuilds the graph (untimed) before each timed iteration.
- **`perf/graaflib/bron_kerbosch_benchmark.cpp`**: `bron_kerbosh_connected_random_cliques` built a connecting path over all vertices and then a clique on top of it, which could re-add edges between consecutive vertices already connected by the path. Guarded with `has_edge`.
- **`perf/graaflib/utils/dataset_reader.cpp`**: loads directed SNAP datasets into an `undirected_graph`; reciprocal directed edges (A→B and B→A) map to the same undirected edge. Guarded with `has_edge`.
- **`perf/graaflib/prim_benchmark.cpp`**: the BFS-based connected-subgraph builder can fire its edge callback twice for the same vertex pair, because `breadth_first_traverse` only marks a vertex "seen" when popped (not pushed) — a quirk already documented in that file's comments. Guarded with `has_edge`.

## Test plan

- [x] Full test suite passes: `774/774` tests (`Graaf_test`)
- [x] `Graaf_perf` builds cleanly
- [x] Ran the affected benchmarks (`bm_add_primitive_numeric_edge`, `bm_add_user_defined_edge`, `bron_kerbosh_connected_random_cliques`) directly to confirm no exceptions are thrown across multiple iterations

🤖 Generated with [Claude Code](https://claude.com/claude-code)