### PR TITLE
fix: remove_edge throws invalid_argument instead of unhandled out_of_range

### DIFF
--- a/include/graaflib/graph.h
+++ b/include/graaflib/graph.h
@@ -210,6 +210,8 @@ class graph {
    *
    * @param  vertex_id_lhs The ID of the first vertex
    * @param  vertex_id_rhs The ID of the second vertex
+   * @throws invalid_argument exception - If no edge exists between the two
+   * vertices
    */
   void remove_edge(vertex_id_t vertex_id_lhs, vertex_id_t vertex_id_rhs);
 

--- a/include/graaflib/graph.tpp
+++ b/include/graaflib/graph.tpp
@@ -203,6 +203,13 @@ void graph<VERTEX_T, EDGE_T, GRAPH_TYPE_V>::add_edge(vertex_id_t vertex_id_lhs,
 template <typename VERTEX_T, typename EDGE_T, graph_type GRAPH_TYPE_V>
 void graph<VERTEX_T, EDGE_T, GRAPH_TYPE_V>::remove_edge(
     vertex_id_t vertex_id_lhs, vertex_id_t vertex_id_rhs) {
+  if (!has_edge(vertex_id_lhs, vertex_id_rhs)) {
+    // TODO(bluppes): replace with std::format once Clang supports it
+    throw std::invalid_argument{"No edge found between vertices [" +
+                                std::to_string(vertex_id_lhs) + "] -> [" +
+                                std::to_string(vertex_id_rhs) + "]."};
+  }
+
   using enum graph_type;
   if constexpr (GRAPH_TYPE_V == DIRECTED) {
     adjacency_list_.at(vertex_id_lhs).erase(vertex_id_rhs);

--- a/test/graaflib/graph_test.cpp
+++ b/test/graaflib/graph_test.cpp
@@ -116,6 +116,36 @@ TYPED_TEST(GraphTest, RemoveEdge) {
   ASSERT_TRUE(graph.has_vertex(vertex_id_2));
 }
 
+TYPED_TEST(GraphTest, RemoveNonExistentEdgeThrows) {
+  // GIVEN - two vertices with no edge between them, so vertex_id_2 has no
+  // entry in the adjacency list
+  using graph_t = typename TestFixture::graph_t;
+  graph_t graph{};
+
+  const auto vertex_id_1{graph.add_vertex(10)};
+  const auto vertex_id_2{graph.add_vertex(20)};
+
+  // WHEN - THEN
+  ASSERT_THROW(
+      {
+        try {
+          graph.remove_edge(vertex_id_2, vertex_id_1);
+        } catch (const std::invalid_argument &ex) {
+          EXPECT_EQ(ex.what(),
+                    fmt::format(
+                        "No edge found between vertices [{}] -> [{}].",
+                        vertex_id_2, vertex_id_1));
+          throw;
+        }
+      },
+      std::invalid_argument);
+
+  // Removing a non-existent edge does not affect the vertices
+  ASSERT_EQ(graph.edge_count(), 0);
+  ASSERT_TRUE(graph.has_vertex(vertex_id_1));
+  ASSERT_TRUE(graph.has_vertex(vertex_id_2));
+}
+
 TYPED_TEST(GraphTest, AddEdge) {
   using graph_t = typename TestFixture::graph_t;
 

--- a/test/graaflib/graph_test.cpp
+++ b/test/graaflib/graph_test.cpp
@@ -132,9 +132,8 @@ TYPED_TEST(GraphTest, RemoveNonExistentEdgeThrows) {
           graph.remove_edge(vertex_id_2, vertex_id_1);
         } catch (const std::invalid_argument &ex) {
           EXPECT_EQ(ex.what(),
-                    fmt::format(
-                        "No edge found between vertices [{}] -> [{}].",
-                        vertex_id_2, vertex_id_1));
+                    fmt::format("No edge found between vertices [{}] -> [{}].",
+                                vertex_id_2, vertex_id_1));
           throw;
         }
       },


### PR DESCRIPTION
## Summary

`remove_edge` used `adjacency_list_.at(...)`, which threw an undocumented, unhandled `std::out_of_range` whenever a vertex had no adjacency-list entry (e.g. it was never used as an edge source). This was inconsistent with the rest of the class's error-handling convention, which throws a descriptive `std::invalid_argument` for invalid input.

## Fix

`remove_edge` now checks `has_edge(...)` up front and throws `std::invalid_argument` with a descriptive message if no edge exists between the two vertices — mirroring the exact pattern already used by `get_edge` (same message format, same style).

This is a pure implementation/behavior fix, no API signature changes. Note it does change runtime behavior beyond just the crash case: removing a non-existent edge now always throws `invalid_argument` rather than sometimes silently no-op'ing (previously it would only silently no-op when both vertices already had adjacency-list entries, and crash otherwise). The linked issue explicitly names this as an acceptable resolution. No internal callers/algorithms depended on the old silent no-op.

Also updated the `remove_edge` doc comment in `graph.h` with the new `@throws`, and added a regression test (`RemoveNonExistentEdgeThrows`, covering both directed and undirected graphs) reproducing the exact scenario from the issue.

## Test plan

- [x] Added `GraphTest.RemoveNonExistentEdgeThrows` covering both directed and undirected graph types
- [x] Full test suite passes locally (773/773 tests)

Fixes #381

🤖 Generated with [Claude Code](https://claude.com/claude-code)