### PR TITLE
fix: vertex_degree/vertex_outdegree undercount self-loops in undirected graphs

### DIFF
--- a/include/graaflib/properties/vertex_properties.tpp
+++ b/include/graaflib/properties/vertex_properties.tpp
@@ -25,7 +25,15 @@ std::size_t vertex_degree(const graaf::graph<V, E, T>& graph,
 template <typename V, typename E, graph_type T>
 std::size_t vertex_outdegree(const graaf::graph<V, E, T>& graph,
                              vertex_id_t vertex_id) {
-  return (graph.get_neighbors(vertex_id)).size();
+  const auto& neighbors{graph.get_neighbors(vertex_id)};
+
+  if constexpr (T == graph_type::UNDIRECTED) {
+    // A self-loop is stored once in the neighbor set, but conventionally
+    // contributes two to the degree of a vertex in an undirected graph.
+    return neighbors.size() + (neighbors.contains(vertex_id) ? 1 : 0);
+  }
+
+  return neighbors.size();
 }
 
 template <typename V, typename E, graph_type T>

--- a/test/graaflib/properties/vertex_properties_test.cpp
+++ b/test/graaflib/properties/vertex_properties_test.cpp
@@ -82,8 +82,8 @@ TEST(DirectedGraphPropertiesTest, VertexDegreeWithSelfLoop) {
   graph.add_edge(vertex_id_1, vertex_id_2, 200);
 
   // THEN
-  // In a directed graph, the self-loop already contributes one to the
-  // outdegree and one to the indegree of vertex_id_1.
+  // In a directed graph, the self-loop contributes one to the outdegree
+  // and one to the indegree of vertex_id_1.
   ASSERT_EQ(vertex_outdegree(graph, vertex_id_1), 2);
   ASSERT_EQ(vertex_indegree(graph, vertex_id_1), 1);
   ASSERT_EQ(vertex_degree(graph, vertex_id_1), 3);
@@ -123,9 +123,12 @@ TEST(UndirectedGraphPropertiesTest, VertexOutDegreeWithSelfLoop) {
 
   // THEN
   // The self-loop on vertex_id_1 contributes two to its degree, per the
-  // standard graph-theory convention.
+  // standard graph-theory convention. For an undirected graph, indegree
+  // is equal to outdegree.
   ASSERT_EQ(vertex_outdegree(graph, vertex_id_1), 3);
   ASSERT_EQ(vertex_outdegree(graph, vertex_id_2), 1);
+  ASSERT_EQ(vertex_indegree(graph, vertex_id_1), 3);
+  ASSERT_EQ(vertex_indegree(graph, vertex_id_2), 1);
 }
 
 TEST(UndirectedGraphPropertiesTest, VertexDegreeWithSelfLoop) {

--- a/test/graaflib/properties/vertex_properties_test.cpp
+++ b/test/graaflib/properties/vertex_properties_test.cpp
@@ -70,6 +70,25 @@ TEST(DirectedGraphPropertiesTest, VertexDegree) {
   ASSERT_EQ(vertex_degree(graph, vertex_id_4), 2);
 }
 
+TEST(DirectedGraphPropertiesTest, VertexDegreeWithSelfLoop) {
+  // GIVEN
+  directed_graph<int, int> graph{};
+
+  const auto vertex_id_1{graph.add_vertex(10)};
+  const auto vertex_id_2{graph.add_vertex(20)};
+
+  // WHEN
+  graph.add_edge(vertex_id_1, vertex_id_1, 100);
+  graph.add_edge(vertex_id_1, vertex_id_2, 200);
+
+  // THEN
+  // In a directed graph, the self-loop already contributes one to the
+  // outdegree and one to the indegree of vertex_id_1.
+  ASSERT_EQ(vertex_outdegree(graph, vertex_id_1), 2);
+  ASSERT_EQ(vertex_indegree(graph, vertex_id_1), 1);
+  ASSERT_EQ(vertex_degree(graph, vertex_id_1), 3);
+}
+
 TEST(UndirectedGraphPropertiesTest, VertexOutDegree) {
   // GIVEN
   undirected_graph<int, int> graph{};
@@ -89,6 +108,40 @@ TEST(UndirectedGraphPropertiesTest, VertexOutDegree) {
   ASSERT_EQ(vertex_outdegree(graph, vertex_id_2), 3);
   ASSERT_EQ(vertex_outdegree(graph, vertex_id_3), 1);
   ASSERT_EQ(vertex_outdegree(graph, vertex_id_4), 1);
+}
+
+TEST(UndirectedGraphPropertiesTest, VertexOutDegreeWithSelfLoop) {
+  // GIVEN
+  undirected_graph<int, int> graph{};
+
+  const auto vertex_id_1{graph.add_vertex(10)};
+  const auto vertex_id_2{graph.add_vertex(20)};
+
+  // WHEN
+  graph.add_edge(vertex_id_1, vertex_id_1, 100);
+  graph.add_edge(vertex_id_1, vertex_id_2, 200);
+
+  // THEN
+  // The self-loop on vertex_id_1 contributes two to its degree, per the
+  // standard graph-theory convention.
+  ASSERT_EQ(vertex_outdegree(graph, vertex_id_1), 3);
+  ASSERT_EQ(vertex_outdegree(graph, vertex_id_2), 1);
+}
+
+TEST(UndirectedGraphPropertiesTest, VertexDegreeWithSelfLoop) {
+  // GIVEN
+  undirected_graph<int, int> graph{};
+
+  const auto vertex_id_1{graph.add_vertex(10)};
+  const auto vertex_id_2{graph.add_vertex(20)};
+
+  // WHEN
+  graph.add_edge(vertex_id_1, vertex_id_1, 100);
+  graph.add_edge(vertex_id_1, vertex_id_2, 200);
+
+  // THEN
+  ASSERT_EQ(vertex_degree(graph, vertex_id_1), 3);
+  ASSERT_EQ(vertex_degree(graph, vertex_id_2), 1);
 }
 
 TEST(UndirectedGraphPropertiesTest, VertexInDegree) {


### PR DESCRIPTION
## Summary

`vertex_degree`/`vertex_outdegree` undercounted self-loops in undirected graphs. `add_edge` inserts the same vertex into its own adjacency set twice for a self-loop, which `std::unordered_set` collapses into a single entry — so a self-loop contributed `1` to degree instead of the conventional `2`.

I first checked whether the recent `add_edge`/`remove_edge` fixes (#393, #394) had already addressed this — they hadn't; those changes target duplicate-edge insertion and missing-edge removal, not self-loop degree accounting. I confirmed the bug still reproduced and fixed it.

## Fix

`vertex_outdegree` now adds 1 for undirected graphs when the neighbor set contains the vertex itself (i.e. it has a self-loop), since the set stores the self-loop only once but the standard convention counts it twice toward degree.

Directed graphs are unaffected: a self-loop there already contributes correctly via one out-edge and one in-edge.

## Test plan

- [x] Added regression tests for self-loop degree in both directed and undirected graphs (`test/graaflib/properties/vertex_properties_test.cpp`)
- [x] Full test suite passes (779 tests)

Fixes #382

🤖 Generated with [Claude Code](https://claude.com/claude-code)