### PR TITLE
docs: clarify get_neighbors() returns out-neighbors only on directed graphs

### DIFF
--- a/include/graaflib/graph.h
+++ b/include/graaflib/graph.h
@@ -166,6 +166,13 @@ class graph {
   /**
    * Get a list of neighbour vertices
    *
+   * For a directed graph, this returns the out-neighbors (successors) only,
+   * i.e. the vertices reachable via an outgoing edge from vertex_id - matching
+   * the vertices you'd find in Adj[vertex_id] in an adjacency-list
+   * representation. It does not include predecessors (in-neighbors). For an
+   * undirected graph, out- and in-neighbors coincide, so this returns all
+   * adjacent vertices.
+   *
    * @param  vertex_id The ID of the vertex
    * @return vertices_t - A list of neighboring vertices
    */


### PR DESCRIPTION
## Summary

`graph::get_neighbors()` had no documentation of its behavior on a `directed_graph`. This is exactly the ambiguity that let #379 slip through: the coloring algorithms (fixed in #392) implicitly assumed `get_neighbors()` returned all adjacent vertices — as it does for an undirected graph — when in fact it correctly returns outgoing edges only on a directed graph.

That behavior is not a bug: it matches the standard convention used throughout computer science for adjacency-list representations (CLRS's `Adj[u]`) and mainstream graph libraries (NetworkX's `DiGraph.neighbors()`/`successors()`, which are explicitly defined to be identical and out-only, with a separate `predecessors()` for in-neighbors). Formal graph theory itself doesn't define a single unqualified "neighbor" for digraphs — it splits into in-neighborhood N⁻(v) and out-neighborhood N⁺(v) — so `get_neighbors()` choosing the out-only convention is a reasonable, well-established choice; it just wasn't documented.

## Change

Docstring-only change to [`get_neighbors()`](include/graaflib/graph.h#L167) explaining that for a directed graph it returns out-neighbors (successors) only, not predecessors, with undirected graphs unaffected (out- and in-neighbors coincide there). No behavior change.

## Test plan

- [x] Full test suite passes (779 tests) — docstring-only change, no code path touched
- [x] `clang-format --dry-run --Werror` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)