### PR TITLE
docs: pin FetchContent GIT_TAG to a release instead of main

### DIFF
--- a/docs/src/quickstart/installation/installation.md
+++ b/docs/src/quickstart/installation/installation.md
@@ -34,10 +34,12 @@ include(FetchContent)
 FetchContent_Declare(
         graaflib
         GIT_REPOSITORY https://github.com/bobluppes/graaf.git
-        GIT_TAG main
+        GIT_TAG v1.2.0
 )
 FetchContent_MakeAvailable(graaflib)
 ```
+
+Pin `GIT_TAG` to a released version rather than `main` - `main` can contain unreleased, potentially breaking changes.
 
 Now you can link your target against `Graaf::Graaf`:
 


### PR DESCRIPTION
## Summary
- The `FetchContent` install example pointed `GIT_TAG` at `main`, which now sits ahead of released breaking-change work queued for `v2.0.0`. Anyone following the docs today would silently pull those changes in.
- Pin the example to the latest release tag (`v1.2.0`) instead, with a short note explaining why.

## Test plan
- [x] Docs-only change, verified rendered Markdown reads correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)