### PR TITLE
feat: add forest alias as a collection of trees

### DIFF
--- a/include/graaflib/tree.h
+++ b/include/graaflib/tree.h
@@ -42,6 +42,13 @@ class tree {
   std::unique_ptr<tree_node> root_{};
 };
 
+/**
+ * A collection of disjoint trees, e.g. the result of an algorithm which
+ * operates on a graph which is not fully connected.
+ */
+template <typename VERTEX_T, typename EDGE_T>
+using forest = std::vector<tree<VERTEX_T, EDGE_T>>;
+
 }  // namespace graaf
 
 #include "tree.tpp"

--- a/test/graaflib/tree_test.cpp
+++ b/test/graaflib/tree_test.cpp
@@ -40,4 +40,20 @@ TEST(TreeTest, CanConstructWithChild) {
   ASSERT_EQ(child->children.size(), 0);
 }
 
+TEST(TreeTest, ForestIsACollectionOfTrees) {
+  // GIVEN
+  using tree_t = tree<int, int>;
+  using forest_t = forest<int, int>;
+
+  // WHEN
+  forest_t forest{};
+  forest.push_back(tree_t{1});
+  forest.push_back(tree_t{2});
+
+  // THEN
+  ASSERT_EQ(forest.size(), 2);
+  ASSERT_EQ(forest[0].root()->value, 1);
+  ASSERT_EQ(forest[1].root()->value, 2);
+}
+
 }  // namespace graaf


### PR DESCRIPTION
## Summary
- Adds `forest<VERTEX_T, EDGE_T>` as an alias for `std::vector<tree<VERTEX_T, EDGE_T>>`
- Part of hardening `tree` ahead of using it as a return type for algorithms such as Kruskal's MST, which legitimately produce a spanning forest (one tree per connected component) rather than a single tree

## Test plan
- [x] `TreeTest.ForestIsACollectionOfTrees` added and passing
- [x] Full `Graaf_test` suite builds and passes