### PR TITLE
docs: add CLAUDE.md with comment guidance for Claude Code

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+# Comments
+
+Only use comments to call out non-obvious rationale or design choices (e.g. why a particular approach was taken, a workaround for a specific limitation, or a subtle invariant) — not to restate what the code already makes clear. Prefer solutions that are self-documenting through clear names and proper abstraction instead of relying on comments to explain what the code does.
+
+Never leak implementation details in documentation comments on public APIs. Document what a public API does and how to use it, not how it is implemented internally — internal details belong in the implementation, not in the public-facing doc comment.


### PR DESCRIPTION
## Summary
- Add a `CLAUDE.md` file at the repo root with guidance for Claude Code sessions working in this project.
- Comments should only call out non-obvious rationale or design choices, not restate what the code already makes clear; prefer self-documenting code via clear names and proper abstraction.
- Public API documentation comments should never leak implementation details — document behavior and usage, not internals.

## Test plan
- N/A — documentation-only change for agent guidance, no code or build changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)